### PR TITLE
Remove the cmdBeginsEvent hook

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -426,7 +426,7 @@ EOF;
     $source,
     $symlink,
     $source_path
-  ): void {
+  ) {
     $fs = new Filesystem();
     $destination_path = str_replace('[web-root]', $this->getWebRoot(), $destination);
 
@@ -468,7 +468,7 @@ EOF;
     $package_name,
     array $package_file_mappings,
     $symlink
-  ): void {
+  ) {
     $this->io->write("Scaffolding files for <comment>$package_name</comment> package");
     foreach ($package_file_mappings as $source => $destination) {
       if ($destination && is_string($destination)) {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -4,7 +4,6 @@ namespace Grasmash\ComposerScaffold;
 
 use Composer\Package\PackageInterface;
 use Composer\Script\Event;
-use Composer\Plugin\CommandEvent;
 use Composer\Composer;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
@@ -51,16 +50,6 @@ class Handler {
   public function __construct(Composer $composer, IOInterface $io) {
     $this->composer = $composer;
     $this->io = $io;
-  }
-
-  /**
-   * Command begins event.
-   *
-   * @param \Composer\Plugin\CommandEvent $commandEvent
-   *   The Composer command event.
-   */
-  public function onCmdBeginsEvent(CommandEvent $commandEvent) {
-    // No function yet.
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,12 +3,10 @@
 namespace Grasmash\ComposerScaffold;
 
 use Composer\Script\Event;
-use Composer\Plugin\CommandEvent;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\Capable;
-use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
 
@@ -50,18 +48,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
   public static function getSubscribedEvents() {
     return [
       ScriptEvents::POST_UPDATE_CMD => 'postCmd',
-      PluginEvents::COMMAND => 'cmdBegins',
     ];
-  }
-
-  /**
-   * Command begins event callback.
-   *
-   * @param \Composer\Plugin\CommandEvent $event
-   *   The Composer event.
-   */
-  public function cmdBegins(CommandEvent $event) {
-    $this->handler->onCmdBeginsEvent($event);
   }
 
   /**


### PR DESCRIPTION
We're not really using the start-of-command capabilities in this plugin, so let's remove it until we actually need it.