### PR TITLE
Fixes #31: Test when 'git' executable is unavailable

### DIFF
--- a/tests/fixtures/scripts/disable-git-bin/git
+++ b/tests/fixtures/scripts/disable-git-bin/git
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 127

--- a/tests/src/Fixtures.php
+++ b/tests/src/Fixtures.php
@@ -108,6 +108,22 @@ class Fixtures {
   }
 
   /**
+   * Return the path to one particular bin path.
+   *
+   * @return string
+   *   Path to project fixture
+   */
+  public function binFixtureDir($bin_name) {
+    $dir = $this->allFixturesDir() . '/scripts/' . $bin_name;
+
+    if (!is_dir($dir)) {
+      throw new \Exception("Requested fixture bin dir $bin_name that does not exist.");
+    }
+
+    return $dir;
+  }
+
+  /**
    * Use in place of ScaffoldFilePath::sourcePath to get a path to a source scaffold fixture.
    *
    * @param string $project_name


### PR DESCRIPTION
Comfirm that scaffold operation still works when 'git' executable is unavailable.