### PR TITLE
Fixes #30: Notify user when a package with scaffold items is required

### DIFF
--- a/src/AllowedPackages.php
+++ b/src/AllowedPackages.php
@@ -36,6 +36,13 @@ class AllowedPackages {
   }
 
   /**
+   * Called when a newly-added package is discovered to contian scaffolding instructions.
+   */
+  public function addedPackageWithScaffolding(PackageInterface $package) {
+    // @todo remember that we saw the package
+  }
+
+  /**
    * Gets a list of all packages that are allowed to copy scaffold files.
    *
    * Configuration for packages specified later will override configuration
@@ -58,6 +65,8 @@ class AllowedPackages {
       unset($allowed_packages[$root_package->getName()]);
       $allowed_packages[$root_package->getName()] = $root_package;
     }
+
+    // @todo handle any newly-added packages that are not already allowed.
 
     return $allowed_packages;
   }

--- a/src/AllowedPackages.php
+++ b/src/AllowedPackages.php
@@ -118,6 +118,9 @@ class AllowedPackages {
       if (!array_key_exists($name, $allowed_packages)) {
         $this->io->write("Package <comment>$name</comment> has scaffold operations, but it is not allowed in the root-level composer.json file.");
       }
+      else {
+        $this->io->write("Package <comment>$name</comment> has scaffold operations, and is already allowed in the root-level composer.json file.");
+      }
     }
 
     // In the future, we will allow this method to add more allowed packages.

--- a/src/AllowedPackages.php
+++ b/src/AllowedPackages.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Grasmash\ComposerScaffold;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Grasmash\ComposerScaffold\Operations\OperationInterface;
+use Grasmash\ComposerScaffold\ScaffoldFilePath;
+
+/**
+ * Determine recusively which packages have been allowed to scaffold files.
+ *
+ * If the root-level composer.json allows drupal/core, and drupal/core allows
+ * drupal/assets, then the later package will also implicitly be allowed.
+ */
+class AllowedPackages {
+
+  /**
+   * The Composer service.
+   *
+   * @var \Composer\Composer
+   */
+  protected $composer;
+
+  protected $manageOptions;
+
+  /**
+   * ManageOptions constructor.
+   */
+  public function __construct($composer, $manageOptions) {
+    $this->composer = $composer;
+    $this->manageOptions = $manageOptions;
+  }
+
+  /**
+   * Gets a list of all packages that are allowed to copy scaffold files.
+   *
+   * Configuration for packages specified later will override configuration
+   * specified by packages listed earlier. In other words, the last listed
+   * package has the highest priority. The root package will always be returned
+   * at the end of the list.
+   *
+   * @return \Composer\Package\PackageInterface[]
+   *   An array of allowed Composer packages.
+   */
+  public function getAllowedPackages(): array {
+    $options = $this->manageOptions->getOptions();
+    $allowed_packages = $this->recursiveGetAllowedPackages($options->allowedPackages());
+
+    // If the root package defines any file mappings, then implicitly add it
+    // to the list of allowed packages. Add it at the end so that it overrides
+    // all the preceding packages.
+    if ($options->hasFileMapping()) {
+      $root_package = $this->composer->getPackage();
+      unset($allowed_packages[$root_package->getName()]);
+      $allowed_packages[$root_package->getName()] = $root_package;
+    }
+
+    return $allowed_packages;
+  }
+
+  /**
+   * Recursivly build a name-to-package mapping from a list of package names.
+   *
+   * @param string[] $packages_to_allow
+   *   List of package names to allow.
+   * @param array $allowed_packages
+   *   Mapping of package names to PackageInterface of packages already accumulated.
+   *
+   * @return array
+   *   Mapping of package names to PackageInterface in priority order.
+   */
+  protected function recursiveGetAllowedPackages(array $packages_to_allow, array $allowed_packages = []) {
+    foreach ($packages_to_allow as $name) {
+      $package = $this->getPackage($name);
+      if ($package && $package instanceof PackageInterface && !array_key_exists($name, $allowed_packages)) {
+        $allowed_packages[$name] = $package;
+
+        $packageOptions = $this->manageOptions->packageOptions($package);
+        $allowed_packages = $this->recursiveGetAllowedPackages($packageOptions->allowedPackages(), $allowed_packages);
+      }
+    }
+    return $allowed_packages;
+  }
+
+  /**
+   * Retrieve a package from the current composer process.
+   *
+   * @param string $name
+   *   Name of the package to get from the current composer installation.
+   *
+   * @return \Composer\Package\PackageInterface|null
+   *   The Composer package.
+   */
+  protected function getPackage(string $name) {
+    return $this->composer->getRepositoryManager()->getLocalRepository()->findPackage($name, '*');
+  }
+
+}

--- a/src/DetectAddingPackagesWithScaffolding.php
+++ b/src/DetectAddingPackagesWithScaffolding.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Grasmash\ComposerScaffold;
+
+use Composer\Installer\PackageEvent;
+
+/**
+ * Manage new packages that are added via 'composer require'.
+ *
+ * This package manages examining all required packages, and informing the
+ * allowed package manager whenever a newly-required package is found to
+ * contain scaffolding instructions.
+ */
+class DetectAddingPackagesWithScaffolding {
+
+  protected $manageAllowedPackages;
+
+  /**
+   * DetectAddingPackagesWithScaffolding constructor.
+   *
+   * @param AllowedPackages $manageAllowedPackages
+   *   The manager that handles allowed packages. We will inform it when new packages are added.
+   */
+  public function __construct(AllowedPackages $manageAllowedPackages) {
+    $this->manageAllowedPackages = $manageAllowedPackages;
+  }
+
+  /**
+   * Handle package events during a 'composer require' operation.
+   *
+   * @param \Composer\Installer\PackageEvent $event
+   *   Composer package event sent on install/update/remove.
+   */
+  public function event(PackageEvent $event) {
+    $operation = $event->getOperation();
+    $jobType = $operation->getJobType();
+    $reason = $operation->getReason();
+
+    // Get the package.
+    $package = ($operation->getJobType() == 'update') ?
+      $operation->getTargetPackage() :
+      $operation->getPackage();
+
+    if (ScaffoldOptions::hasOptions($package->getExtra())) {
+      $this->manageAllowedPackages->addedPackageWithScaffolding($package);
+    }
+  }
+
+}

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -169,7 +169,7 @@ class Handler {
 
     // Analyze the list of file mappings, and determine which take priority.
     $scaffoldCollection = new OperationCollection($this->io);
-    $locationReplacements = $this->getLocationReplacements();
+    $locationReplacements = $this->manageOptions->getLocationReplacements();
     $scaffoldCollection->coalateScaffoldFiles($file_mappings, $locationReplacements);
 
     // Write the collected scaffold files to the designated location on disk.
@@ -218,21 +218,6 @@ class Handler {
     $filesystem = new Filesystem();
     $filesystem->ensureDirectoryExists($vendorDir);
     return $filesystem->normalizePath(realpath($vendorDir));
-  }
-
-  /**
-   * GetLocationReplacements creates an interpolator for the 'locations' element.
-   *
-   * The interpolator returned will replace a path string with the tokens
-   * defined in the 'locations' element.
-   *
-   * Note that only the root package may define locations.
-   *
-   * @return Interpolator
-   *   Object that will do replacements in a string using tokens in 'locations' element.
-   */
-  public function getLocationReplacements() : Interpolator {
-    return (new Interpolator())->setData($this->manageOptions->getOptions()->ensureLocations());
   }
 
   /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -58,7 +58,7 @@ class Handler {
     $this->composer = $composer;
     $this->io = $io;
     $this->manageOptions = new ManageOptions($composer);
-    $this->manageAllowedPackages = new AllowedPackages($composer, $this->manageOptions);
+    $this->manageAllowedPackages = new AllowedPackages($composer, $io, $this->manageOptions);
     $this->postPackageListeners = [];
   }
 

--- a/src/ManageGitIgnore.php
+++ b/src/ManageGitIgnore.php
@@ -84,17 +84,17 @@ class ManageGitIgnore {
   /**
    * Determine whether we should manage gitignore files.
    *
-   * @param array $options
+   * @param ScaffoldOptions $options
    *   Configuration options from the composer.json extras section.
    *
    * @return bool
    *   Whether or not gitignore files should be managed.
    */
-  public function managementOfGitIgnoreEnabled(array $options) {
+  public function managementOfGitIgnoreEnabled(ScaffoldOptions $options) {
     // If the composer.json stipulates whether gitignore is managed or not,
     // then follow its recommendation.
-    if (isset($options['gitignore'])) {
-      return $options['gitignore'];
+    if ($options->hasGitIgnore()) {
+      return $options->gitIgnore();
     }
     // Do not manage .gitignore if there is no repository here.
     if (!$this->isRepository()) {
@@ -111,10 +111,10 @@ class ManageGitIgnore {
    * @param array $files
    *   A list of scaffold results, each of which holds a path and whether
    *   or not that file is managed.
-   * @param array $options
+   * @param ScaffoldOptions $options
    *   Configuration options from the composer.json extras section.
    */
-  public function manageIgnored(array $files, array $options) {
+  public function manageIgnored(array $files, ScaffoldOptions $options) {
     if (!$this->managementOfGitIgnoreEnabled($options)) {
       return;
     }

--- a/src/ManageOptions.php
+++ b/src/ManageOptions.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Grasmash\ComposerScaffold;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Grasmash\ComposerScaffold\Operations\OperationInterface;
+use Grasmash\ComposerScaffold\ScaffoldFilePath;
+
+/**
+ * Per-project options from the 'extras' section of the composer.json file.
+ *
+ * Projects that describe scaffold files do so via their scaffold options.
+ * This data is pulled from the 'composer-scaffold' portion of the extras
+ * section of the project data.
+ */
+class ManageOptions {
+
+  /**
+   * The Composer service.
+   *
+   * @var \Composer\Composer
+   */
+  protected $composer;
+
+  /**
+   * ManageOptions constructor.
+   */
+  public function __construct($composer) {
+    $this->composer = $composer;
+  }
+
+  /**
+   * Get the root-level scaffold options for this project.
+   *
+   * @return ScaffoldOptions
+   *   The scaffold otpions object
+   */
+  public function getOptions() : ScaffoldOptions {
+    return $this->packageOptions($this->composer->getPackage());
+  }
+
+  /**
+   * The scaffold options for the stipulated project.
+   *
+   * @param \Composer\Package\PackageInterface $package
+   *   The package to fetch the scaffold options from.
+   *
+   * @return ScaffoldOptions
+   *   The scaffold otpions object
+   */
+  public function packageOptions(PackageInterface $package) : ScaffoldOptions {
+    return ScaffoldOptions::create($package->getExtra());
+  }
+
+}

--- a/src/Operations/AppendOp.php
+++ b/src/Operations/AppendOp.php
@@ -9,6 +9,7 @@ use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use Grasmash\ComposerScaffold\Interpolator;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 /**
@@ -67,7 +68,7 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
     $interpolator = $destination->getInterpolator();
     $this->addInterpolationData($interpolator);
     $destination_path = $destination->fullPath();
@@ -81,7 +82,7 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
     // First, scaffold the original file. Disable symlinking, because we
     // need a copy of the file if we're going to append / prepend to it.
     @unlink($destination_path);
-    $this->originalOp()->process($destination, $io, ['symlink' => FALSE] + $options);
+    $this->originalOp()->process($destination, $io, $options->overrideSymlink(FALSE));
 
     // Fetch the prepend contents, if provided.
     $prependContents = '';

--- a/src/Operations/OperationCollection.php
+++ b/src/Operations/OperationCollection.php
@@ -5,9 +5,10 @@ declare(strict_types = 1);
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
-use Grasmash\ComposerScaffold\ScaffoldFileInfo;
 use Grasmash\ComposerScaffold\Interpolator;
+use Grasmash\ComposerScaffold\ScaffoldFileInfo;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
 
 /**
  * OperationCollection keeps track of the collection of files to be scaffolded.
@@ -115,13 +116,13 @@ class OperationCollection {
   /**
    * Scaffolds the files in our scaffold collection, package-by-package.
    *
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Configuration options from the top-level composer.json file.
    *
    * @return ScaffoldResult[]
    *   Associative array of destination path : scaffold result for each scaffolded file.
    */
-  public function processScaffoldFiles(array $options) {
+  public function processScaffoldFiles(ScaffoldOptions $options) {
     $result = [];
     // We could simply scaffold all of the files from $list_of_scaffold_files,
     // which contain only the list of files to be processed. We iterate over

--- a/src/Operations/OperationFactory.php
+++ b/src/Operations/OperationFactory.php
@@ -7,8 +7,9 @@ namespace Grasmash\ComposerScaffold\Operations;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
-use Grasmash\ComposerScaffold\ScaffoldFilePath;
 use Grasmash\ComposerScaffold\ScaffoldFileInfo;
+use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
 
 /**
  * Create Scaffold operation objects based on provided metadata.
@@ -69,46 +70,7 @@ class OperationFactory {
     if (!isset($value['mode'])) {
       $value['mode'] = 'replace';
     }
-    // Accept 'true' or 'always' for the 'overwrite' property. Any other value
-    // is treated as 'false'.
-    if (isset($value['overwrite'])) {
-      $value['overwrite'] = $this->normalizeOverwrite($value['overwrite']);
-    }
     return $value;
-  }
-
-  /**
-   * Convert overwrite value from one of the allowed values to a boolean.
-   *
-   * Any value not recognized as 'true' is interpreted as 'false'.
-   *
-   * @param mixed $overwrite
-   *   Overwrite value as specified by user.
-   *
-   * @return bool
-   *   Normalized overwrite value expressed as a boolean.
-   */
-  protected function normalizeOverwrite($overwrite) : bool {
-    return ($overwrite === TRUE) ||
-      ($overwrite == 'true') ||
-      ($overwrite == 'always');
-  }
-
-  /**
-   * Determine whether we should default to 'overwrite' true, or 'overwrite' false.
-   *
-   * @param array $options
-   *   Global settings from extras.composer-scaffold.
-   *
-   * @return bool
-   *   The default value for the overwrite option.
-   */
-  protected function getDefaultOverwrite(array $options) : bool {
-    if (isset($options['overwrite'])) {
-      return $this->normalizeOverwrite($options['overwrite']);
-    }
-
-    return TRUE;
   }
 
   /**
@@ -120,13 +82,13 @@ class OperationFactory {
    *   The destination path for the scaffold file. Used only for error messages.
    * @param mixed $value
    *   The metadata for this operation object, which varies by operation type.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Configuration options from the top-level composer.json file.
    *
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   The scaffolding operation object (skip, replace, etc.)
    */
-  public function createScaffoldOp(PackageInterface $package, $dest_rel_path, $value, array $options) : OperationInterface {
+  public function createScaffoldOp(PackageInterface $package, $dest_rel_path, $value, ScaffoldOptions $options) : OperationInterface {
     switch ($value['mode']) {
       case 'skip':
         return new SkipOp();
@@ -152,17 +114,17 @@ class OperationFactory {
    *   The destination path for the scaffold file. Used only for error messages.
    * @param array $metadata
    *   The metadata for this operation object, i.e. the relative 'path'.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Configuration options from the top-level composer.json file.
    *
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   A scaffold replace operation obejct.
    */
-  protected function createReplaceOp(PackageInterface $package, string $dest_rel_path, array $metadata, array $options) : OperationInterface {
+  protected function createReplaceOp(PackageInterface $package, string $dest_rel_path, array $metadata, ScaffoldOptions $options) : OperationInterface {
     $op = new ReplaceOp();
 
     // If this op does not provide an 'overwrite' value, then fill in the default.
-    $metadata += ['overwrite' => $this->getDefaultOverwrite($options)];
+    $metadata += ['overwrite' => $options->overwrite()];
     if (!isset($metadata['path'])) {
       throw new \Exception("'path' component required for 'replace' operations.");
     }
@@ -188,13 +150,13 @@ class OperationFactory {
    *   The destination path for the scaffold file. Used only for error messages.
    * @param array $metadata
    *   The metadata for this operation object, i.e. the relative 'path'.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Configuration options from the top-level composer.json file.
    *
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   A scaffold replace operation obejct.
    */
-  protected function createAppendOp(PackageInterface $package, string $dest_rel_path, array $metadata, array $options) : OperationInterface {
+  protected function createAppendOp(PackageInterface $package, string $dest_rel_path, array $metadata, ScaffoldOptions $options) : OperationInterface {
 
     $op = new AppendOp();
 

--- a/src/Operations/OperationInterface.php
+++ b/src/Operations/OperationInterface.php
@@ -6,6 +6,7 @@ namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
 
 /**
  * Data file that keeps track of one scaffold file's source, destination, and package.
@@ -19,12 +20,12 @@ interface OperationInterface {
    *   Scaffold file's destination path.
    * @param \Composer\IO\IOInterface $io
    *   IOInterface to writing to.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Various options that may alter the behavior of the operation.
    *
    * @return ScaffoldResult
    *   Result of the scaffolding operation (is this file managed or unmanaged, etc.)
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult;
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult;
 
 }

--- a/src/Operations/ReplaceOp.php
+++ b/src/Operations/ReplaceOp.php
@@ -7,8 +7,9 @@ namespace Grasmash\ComposerScaffold\Operations;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 /**
  * Scaffold operation to copy or symlink from source to destination.
@@ -69,9 +70,8 @@ class ReplaceOp implements OperationInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
     $fs = new Filesystem();
-    $options += ['symlink' => FALSE];
 
     $destination_path = $destination->fullPath();
 
@@ -87,7 +87,7 @@ class ReplaceOp implements OperationInterface {
     @unlink($destination_path);
     $fs->ensureDirectoryExists(dirname($destination_path));
 
-    if ($options['symlink'] == TRUE) {
+    if ($options->symlink() == TRUE) {
       return $this->symlinkScaffold($destination, $io, $options);
     }
     return $this->copyScaffold($destination, $io, $options);
@@ -100,10 +100,10 @@ class ReplaceOp implements OperationInterface {
    *   Scaffold file to process.
    * @param \Composer\IO\IOInterface $io
    *   IOInterface to writing to.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Various options that may alter the behavior of the operation.
    */
-  public function copyScaffold(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult {
+  public function copyScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
     $interpolator = $destination->getInterpolator();
     $this->getSource()->addInterpolationData($interpolator);
 
@@ -124,10 +124,10 @@ class ReplaceOp implements OperationInterface {
    *   Scaffold file to process.
    * @param \Composer\IO\IOInterface $io
    *   IOInterface to writing to.
-   * @param array $options
+   * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Various options that may alter the behavior of the operation.
    */
-  public function symlinkScaffold(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult {
+  public function symlinkScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
     $interpolator = $destination->getInterpolator();
     $source_path = $this->getSource()->fullPath();
     $destination_path = $destination->fullPath();

--- a/src/Operations/SkipOp.php
+++ b/src/Operations/SkipOp.php
@@ -6,6 +6,7 @@ namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
 
 /**
  * Scaffold operation to skip a scaffold file (do nothing).
@@ -17,7 +18,7 @@ class SkipOp implements OperationInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, array $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
     $interpolator = $destination->getInterpolator();
     $io->write($interpolator->interpolate("  - Skip <info>[dest-rel-path]</info>: disabled"));
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,10 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
+use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\CommandEvent;
 
 /**
  * Composer plugin for handling drupal scaffold.
@@ -48,6 +52,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
   public static function getSubscribedEvents() {
     return [
       ScriptEvents::POST_UPDATE_CMD => 'postCmd',
+      PackageEvents::POST_PACKAGE_INSTALL => 'postPackage',
+      PluginEvents::COMMAND => 'onCommand',
     ];
   }
 
@@ -59,6 +65,28 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
    */
   public function postCmd(Event $event) {
     $this->handler->onPostCmdEvent($event);
+  }
+
+  /**
+   * Post package event behaviour.
+   *
+   * @param \Composer\Installer\PackageEvent $event
+   *   Composer package event sent on install/update/remove.
+   */
+  public function postPackage(PackageEvent $event) {
+    $this->handler->onPostPackageEvent($event);
+  }
+
+  /**
+   * Pre command event callback.
+   *
+   * @param \Composer\Plugin\CommandEvent $event
+   *   The Composer command event.
+   */
+  public function onCommand(CommandEvent $event) {
+    if ($event->getCommandName() == 'require') {
+      $this->handler->beforeRequire($event);
+    }
   }
 
 }

--- a/src/ScaffoldFileInfo.php
+++ b/src/ScaffoldFileInfo.php
@@ -125,12 +125,12 @@ class ScaffoldFileInfo {
    *
    * @param \Composer\IO\IOInterface $io
    *   The scaffold file to be processed.
-   * @param array $options
+   * @param ScaffoldOptions $options
    *   Assorted operational options, e.g. whether the destination should be a symlink.
    *
    * @throws \Exception
    */
-  public function process(IOInterface $io, array $options) {
+  public function process(IOInterface $io, ScaffoldOptions $options) {
     return $this->op()->process($this->destination, $io, $options);
   }
 

--- a/src/ScaffoldOptions.php
+++ b/src/ScaffoldOptions.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Grasmash\ComposerScaffold;
+
+use Composer\IO\IOInterface;
+use Composer\Util\Filesystem;
+use Grasmash\ComposerScaffold\Operations\OperationInterface;
+use Grasmash\ComposerScaffold\ScaffoldFilePath;
+
+/**
+ * Per-project options from the 'extras' section of the composer.json file.
+ *
+ * Projects that describe scaffold files do so via their scaffold options.
+ * This data is pulled from the 'composer-scaffold' portion of the extras
+ * section of the project data.
+ */
+class ScaffoldOptions {
+
+  protected $options = [];
+
+  /**
+   * ScaffoldOptions constructor.
+   *
+   * @param array $options
+   *   The scaffold options taken from the 'composer-scaffold' section.
+   */
+  protected function __construct(array $options) {
+    $this->options = $options + [
+      "allowed-packages" => [],
+      "locations" => [],
+      "symlink" => FALSE,
+      "overwrite" => TRUE,
+      "file-mapping" => [],
+    ];
+  }
+
+  /**
+   * Determine if the provided 'extras' section has scaffold options.
+   *
+   * @param array $extras
+   *   The contents of the 'extras' section.
+   *
+   * @return bool
+   *   True if scaffold options have been declared
+   */
+  public static function hasOptions(array $extras) : bool {
+    return array_key_exists('composer-scaffold', $extras);
+  }
+
+  /**
+   * Create a scaffold options object.
+   *
+   * @param array $extras
+   *   The contents of the 'extras' section.
+   *
+   * @return self
+   *   The scaffold options object representing the provided scaffold options
+   */
+  public static function create(array $extras) : self {
+    $options = static::hasOptions($extras) ? $extras['composer-scaffold'] : [];
+    return new self($options);
+  }
+
+  /**
+   * Create a scaffold option object with default values.
+   *
+   * @return self
+   *   A scaffold options object with default values
+   */
+  public static function default() : self {
+    return new self([]);
+  }
+
+  /**
+   * Create a new scaffold options object with some values overridden.
+   *
+   * @param array $options
+   *   Override values.
+   *
+   * @return self
+   *   The scaffold options object representing the provided scaffold options
+   */
+  protected function override(array $options) {
+    return new self($options + $this->options);
+  }
+
+  /**
+   * Create a new scaffold options object with a new value in the 'symlink' variable.
+   *
+   * @return self
+   *   The scaffold options object representing the provided scaffold options
+   */
+  public function overrideSymlink(bool $symlink) {
+    return $this->override(['symlink' => $symlink]);
+  }
+
+  /**
+   * Determine whether any allowed packages were defined.
+   *
+   * @return bool
+   *   Whether there are allowed packages
+   */
+  public function hasAllowedPackages() : bool {
+    return !empty($this->allowedPackages());
+  }
+
+  /**
+   * The allowed packages from these options.
+   *
+   * @return array
+   *   The list of allowed packages
+   */
+  public function allowedPackages() : array {
+    return $this->options['allowed-packages'];
+  }
+
+  /**
+   * The location mapping table, e.g. 'webroot' => './'.
+   *
+   * @return array
+   *   A map of name : location values
+   */
+  public function locations() : array {
+    return $this->options['locations'];
+  }
+
+  /**
+   * Determine whether a given named location is defined.
+   *
+   * @return bool
+   *   True if the specified named location exist.
+   */
+  public function hasLocation(string $name) : bool {
+    return array_key_exists($name, $this->locations());
+  }
+
+  /**
+   * Get a specific named location.
+   *
+   * @param string $name
+   *   The name of the location to fetch.
+   * @param string $default
+   *   The value to return if the requested location is not defined.
+   *
+   * @return string
+   *   The value of the provided named location
+   */
+  public function getLocation(string $name, string $default = '') : string {
+    return $this->hasLocation($name) ? $this->locations()[$name] : $default;
+  }
+
+  /**
+   * Return the value of a specific named location, or throw.
+   *
+   * @param string $name
+   *   The name of the location to fetch.
+   * @param string $message
+   *   The message to pass into the exception if the requested location
+   *   does not exist.
+   *
+   * @return string
+   *   The value of the provided named location
+   */
+  public function requiredLocation(string $name, string $message) : string {
+    if (!$this->hasLocation($name)) {
+      throw new \Exception($message);
+    }
+    return $this->getLocation($name);
+  }
+
+  /**
+   * Ensure that all of the locatons defined in the scaffold filed exist.
+   *
+   * Create them on the filesystem if they do not.
+   */
+  public function ensureLocations() : array {
+    $fs = new Filesystem();
+    $locations = $this->locations() + ['web_root' => './'];
+    $locations = array_map(
+      function ($location) use ($fs) {
+        $fs->ensureDirectoryExists($location);
+        $location = realpath($location);
+        return $location;
+      },
+      $locations
+    );
+    return $locations;
+  }
+
+  /**
+   * Determine whether the options have defined symlink mode.
+   *
+   * @return bool
+   *   Whether or not 'symlink' mode
+   */
+  public function symlink() : bool {
+    return $this->options['symlink'];
+  }
+
+  /**
+   * Determine whether these options contain file mappings.
+   *
+   * @return bool
+   *   Whether or not the scaffold options contain any file mappings
+   */
+  public function hasFileMapping() : bool {
+    return !empty($this->fileMapping());
+  }
+
+  /**
+   * Return the actual file mappings.
+   *
+   * @return array
+   *   File mappings for just this config type.
+   */
+  public function fileMapping() : array {
+    return $this->options['file-mapping'];
+  }
+
+  /**
+   * Whether the options have the global overwrite preference.
+   *
+   * @return bool
+   *   The global the overwrite option
+   */
+  public function overwrite() : bool {
+    return $this->options['overwrite'];
+  }
+
+  /**
+   * Whether the scaffold options have defined a value for the 'gitignore' option.
+   *
+   * @return bool
+   *   Whether or not there is a 'gitignore' option setting
+   */
+  public function hasGitIgnore() : bool {
+    return isset($this->options['gitignore']);
+  }
+
+  /**
+   * The value of the 'gitignore' option.
+   *
+   * @return bool
+   *   The 'gitignore' option, or TRUE if undefined.
+   */
+  public function gitIgnore() : bool {
+    return $this->hasGitIgnore() ? $this->options['gitignore'] : TRUE;
+  }
+
+}

--- a/src/ScaffoldOptions.php
+++ b/src/ScaffoldOptions.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Grasmash\ComposerScaffold;
 
 use Composer\IO\IOInterface;
-use Composer\Util\Filesystem;
 use Grasmash\ComposerScaffold\Operations\OperationInterface;
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
 
@@ -168,25 +167,6 @@ class ScaffoldOptions {
       throw new \Exception($message);
     }
     return $this->getLocation($name);
-  }
-
-  /**
-   * Ensure that all of the locatons defined in the scaffold filed exist.
-   *
-   * Create them on the filesystem if they do not.
-   */
-  public function ensureLocations() : array {
-    $fs = new Filesystem();
-    $locations = $this->locations() + ['web_root' => './'];
-    $locations = array_map(
-      function ($location) use ($fs) {
-        $fs->ensureDirectoryExists($location);
-        $location = realpath($location);
-        return $location;
-      },
-      $locations
-    );
-    return $locations;
   }
 
   /**

--- a/tests/fixtures/composer-hooks-nothing-allowed-fixture/assets/robots-default.txt
+++ b/tests/fixtures/composer-hooks-nothing-allowed-fixture/assets/robots-default.txt
@@ -1,0 +1,1 @@
+# robots.txt fixture scaffolded from "file-mappings" in composer-hooks-fixture composer.json fixture.

--- a/tests/fixtures/composer-hooks-nothing-allowed-fixture/composer.json.tmpl
+++ b/tests/fixtures/composer-hooks-nothing-allowed-fixture/composer.json.tmpl
@@ -1,0 +1,63 @@
+{
+  "name": "fixtures/drupal-drupal",
+  "type": "project",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "repositories": {
+    "composer-scaffold": {
+      "type": "path",
+      "url": "__PROJECT_ROOT__",
+      "options": {
+        "symlink": true
+      }
+    },
+    "drupal-core-fixture": {
+      "type": "path",
+      "url": "../drupal-core-fixture",
+      "options": {
+        "symlink": true
+      }
+    },
+    "drupal-assets-fixture": {
+      "type": "path",
+      "url": "../drupal-assets-fixture",
+      "options": {
+        "symlink": true
+      }
+    },
+    "scaffold-override-fixture": {
+      "type": "path",
+      "url": "../scaffold-override-fixture",
+      "options": {
+        "symlink": true
+      }
+    }
+  },
+  "require": {
+    "grasmash/composer-scaffold": "*",
+    "fixtures/drupal-core-fixture": "*"
+  },
+  "extra": {
+    "composer-scaffold": {
+      "locations": {
+        "web-root": "./"
+      },
+      "symlink": __SYMLINK__,
+      "file-mapping": {
+        "[web-root]/.htaccess": false,
+        "[web-root]/robots.txt": "assets/robots-default.txt"
+      }
+    },
+    "installer-paths": {
+      "core": ["type:drupal-core"],
+      "modules/contrib/{$name}": ["type:drupal-module"],
+      "modules/custom/{$name}": ["type:drupal-custom-module"],
+      "profiles/contrib/{$name}": ["type:drupal-profile"],
+      "profiles/custom/{$name}": ["type:drupal-custom-profile"],
+      "themes/contrib/{$name}": ["type:drupal-theme"],
+      "themes/custom/{$name}": ["type:drupal-custom-theme"],
+      "libraries/{$name}": ["type:drupal-library"],
+      "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
+    }
+  }
+}

--- a/tests/fixtures/drupal-drupal-test-overwrite/composer.json.tmpl
+++ b/tests/fixtures/drupal-drupal-test-overwrite/composer.json.tmpl
@@ -53,15 +53,15 @@
         "[web-root]/robots.txt": "assets/robots-default.txt",
         "make-me.txt": {
           "path": "assets/replacement.txt",
-          "overwrite": "false"
+          "overwrite": false
         },
         "keep-me.txt": {
           "path": "assets/replacement.txt",
-          "overwrite": "false"
+          "overwrite": false
         },
         "replace-me.txt": {
           "path": "assets/replacement.txt",
-          "overwrite": "true"
+          "overwrite": true
         }
       }
     },

--- a/tests/fixtures/empty-fixture-allowing-core/composer.json
+++ b/tests/fixtures/empty-fixture-allowing-core/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "fixtures/empty-fixture-allowing-core",
+  "extra": {
+    "composer-scaffold": {
+      "allowed-packages": [
+        "fixtures/drupal-core-fixture"
+      ],
+      "locations": {
+        "web-root": "./"
+      }
+    }
+  }
+}

--- a/tests/src/ExecTrait.php
+++ b/tests/src/ExecTrait.php
@@ -27,7 +27,7 @@ trait ExecTrait {
     $process->setTimeout(300)->setIdleTimeout(300)->run();
     $exitCode = $process->getExitCode();
     if (0 != $exitCode) {
-      throw new \Exception("Exit code: $exitCode\n\n" . $process->getErrorOutput());
+      throw new \Exception("Exit code: $exitCode\n\n" . $process->getErrorOutput() . "\n\n" . $process->getOutput());
     }
     return [$process->getOutput(), $process->getErrorOutput()];
   }

--- a/tests/src/Functional/ManageGitIgnoreTest.php
+++ b/tests/src/Functional/ManageGitIgnoreTest.php
@@ -184,15 +184,8 @@ EOT;
     exec('git --help', $output, $status);
     $this->assertEquals(127, $status);
 
-    $process = new Process('git --help');
-    $process->run();
-    if (127 != $process->getExitCode()) {
-      $this->markTestSkipped('For some reason, Symfony/Process is not passing the PATH environment variable.');
-    }
-
     // Run the scaffold command.
-    $output = $this->fixtures->runScaffold($sut);
-    $this->assertEquals('', $output);
+    exec('composer composer:scaffold', $output, $status);
     $this->assertFileExists($sut . '/docroot/index.php');
     $this->assertFileNotExists($sut . '/docroot/sites/default/.gitignore');
   }

--- a/tests/src/Functional/ManageGitIgnoreTest.php
+++ b/tests/src/Functional/ManageGitIgnoreTest.php
@@ -164,6 +164,7 @@ EOT;
     // Note that the drupal-composer-drupal-project fixture does not
     // have any configuration settings related to .gitignore management.
     $sut = $this->createSutWithGit('drupal-composer-drupal-project');
+    $this->assertFileNotExists($sut . '/docroot/sites/default/.gitignore');
 
     $this->assertFileNotExists($sut . '/docroot/index.php');
     $this->assertFileNotExists($sut . '/docroot/sites/.gitignore');
@@ -183,8 +184,15 @@ EOT;
     exec('git --help', $output, $status);
     $this->assertEquals(127, $status);
 
+    $process = new Process('git --help');
+    $process->run();
+    if (127 != $process->getExitCode()) {
+      $this->markTestSkipped('For some reason, Symfony/Process is not passing the PATH environment variable.');
+    }
+
     // Run the scaffold command.
-    $this->fixtures->runScaffold($sut);
+    $output = $this->fixtures->runScaffold($sut);
+    $this->assertEquals('', $output);
     $this->assertFileExists($sut . '/docroot/index.php');
     $this->assertFileNotExists($sut . '/docroot/sites/default/.gitignore');
   }

--- a/tests/src/Integration/AppendOpTest.php
+++ b/tests/src/Integration/AppendOpTest.php
@@ -6,10 +6,11 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Grasmash\ComposerScaffold\Handler;
-use PHPUnit\Framework\TestCase;
-use Grasmash\ComposerScaffold\Tests\Fixtures;
 use Grasmash\ComposerScaffold\Operations\AppendOp;
 use Grasmash\ComposerScaffold\Operations\ReplaceOp;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
+use Grasmash\ComposerScaffold\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Grasmash\ComposerScaffold\Operations\AppendOp
@@ -25,7 +26,7 @@ class AppendOpTest extends TestCase {
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
 
-    $options = [];
+    $options = ScaffoldOptions::default();
 
     $originalOp = new ReplaceOp();
     $originalOp->setSource($source);

--- a/tests/src/Integration/ReplaceOpTest.php
+++ b/tests/src/Integration/ReplaceOpTest.php
@@ -6,9 +6,10 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Grasmash\ComposerScaffold\Handler;
-use PHPUnit\Framework\TestCase;
-use Grasmash\ComposerScaffold\Tests\Fixtures;
 use Grasmash\ComposerScaffold\Operations\ReplaceOp;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
+use Grasmash\ComposerScaffold\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Grasmash\ComposerScaffold\Operations\ReplaceOp
@@ -24,7 +25,7 @@ class ReplaceOpTest extends TestCase {
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
 
-    $options = [];
+    $options = ScaffoldOptions::default();
 
     $sut = new ReplaceOp();
     $sut->setSource($source);

--- a/tests/src/Integration/SkipOpTest.php
+++ b/tests/src/Integration/SkipOpTest.php
@@ -6,9 +6,10 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Grasmash\ComposerScaffold\Handler;
-use PHPUnit\Framework\TestCase;
-use Grasmash\ComposerScaffold\Tests\Fixtures;
 use Grasmash\ComposerScaffold\Operations\SkipOp;
+use Grasmash\ComposerScaffold\ScaffoldOptions;
+use Grasmash\ComposerScaffold\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Grasmash\ComposerScaffold\Operations\SkipOp
@@ -24,7 +25,7 @@ class SkipOpTest extends TestCase {
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
 
-    $options = [];
+    $options = ScaffoldOptions::default();
 
     $sut = new SkipOp();
 

--- a/tests/src/Unit/HandlerTest.php
+++ b/tests/src/Unit/HandlerTest.php
@@ -39,7 +39,6 @@ class HandlerTest extends TestCase {
 
   /**
    * @covers ::getWebRoot
-   * @covers ::getOptions
    */
   public function testGetWebRoot() {
     $expected = './build/docroot';


### PR DESCRIPTION
Create a ManageOptions manager and a ScaffoldOptions class to provide an API for 'extra' configuration option arrays.

Factor out the code to manage "allowed" packages into its own class, and leverage that to manage the list of packages with scaffold files `require`d during this command so that we may print out an appropriate confirmation / warning message, depending on whether the package is allowed to scaffold or not.