### PR TITLE
Fixes #36: Remove php-7-specific directives to support php 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: php
 
 php:
   - 7.0
+  - 5.6
 sudo: false
 
 before_script:
   - travis_retry composer install --prefer-source --no-interaction
 
-script: composer test
+script: composer unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - php: 7.2
     env: OP=install
   - php: 5.6
-    env: OP=update
+    env: OP="update --prefer-lowest"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: php
 
-php:
-  - 7.0
-  - 5.6
+matrix:
+  fast_finish: true
+  include:
+  - php: 7.2
+    env: OP=install
+  - php: 5.6
+    env: OP=update
+
 sudo: false
 
 before_script:
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer $OP --prefer-source --no-interaction
 
-script: composer unit
+script:
+  - composer unit

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   },
   "require-dev": {
     "composer/composer": "dev-master",
-    "phpunit/phpunit": "^4.8.36|^6",
+    "phpunit/phpunit": "^5.7.27|^6",
     "squizlabs/php_codesniffer": "^3.4.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "drupal/coder": "^8.3.3"

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
   },
   "require-dev": {
     "composer/composer": "dev-master",
-    "phpunit/phpunit": "^4|^6",
-    "squizlabs/php_codesniffer": "^3",
+    "phpunit/phpunit": "^4.8.36|^6",
+    "squizlabs/php_codesniffer": "^3.4.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-    "drupal/coder": "^8.3.1"
+    "drupal/coder": "^8.3.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   },
   "require-dev": {
     "composer/composer": "dev-master",
-    "phpunit/phpunit": "^6",
+    "phpunit/phpunit": "^4|^6",
     "squizlabs/php_codesniffer": "^3",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "drupal/coder": "^8.3.1"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "composer-plugin",
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": ">=7.0.8",
+    "php": ">=5.6",
     "composer-plugin-api": "^1.0.0"
   },
   "autoload": {
@@ -38,10 +38,7 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "sort-packages": true,
-    "platform": {
-      "php": "7.0.8"
-    }
+    "sort-packages": true
   },
   "require-dev": {
     "composer/composer": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5acbedb2bb5d9191dfe035fd653e93a8",
+    "content-hash": "0e66d4be3362b3dc20b5ef3f7f074612",
     "packages": [],
     "packages-dev": [
         {
@@ -377,32 +377,34 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -422,12 +424,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "drupal/coder",
@@ -534,25 +536,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -575,109 +580,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -896,40 +799,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -944,7 +847,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -955,7 +858,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1145,16 +1048,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -1163,35 +1066,33 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
+                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "~1.1"
             },
             "bin": [
                 "phpunit"
@@ -1199,7 +1100,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -1225,33 +1126,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-01T05:22:47+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<6.0"
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1259,7 +1160,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -1274,7 +1175,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
+                    "email": "sb@sebastian-bergmann.de",
                     "role": "lead"
                 }
             ],
@@ -1285,7 +1186,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "psr/log",
@@ -1381,30 +1282,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1435,38 +1336,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1493,32 +1394,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1543,34 +1444,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1610,27 +1511,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.2"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1638,7 +1539,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1661,34 +1562,33 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1708,77 +1608,32 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1806,7 +1661,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2039,21 +1894,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.27",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "15a9104356436cb26e08adab97706654799d31d8"
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/15a9104356436cb26e08adab97706654799d31d8",
-                "reference": "15a9104356436cb26e08adab97706654799d31d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0|~4.0",
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -2065,11 +1920,11 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3|~4.0",
+                "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.3|~4.0"
+                "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2080,7 +1935,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2107,44 +1962,51 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-08T09:29:13+00:00"
+            "time": "2019-04-08T14:23:48+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v3.4.27",
+            "name": "symfony/contracts",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "681afbb26488903c5ac15e63734f1d8ac430c9b9"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/681afbb26488903c5ac15e63734f1d8ac430c9b9",
-                "reference": "681afbb26488903c5ac15e63734f1d8ac430c9b9",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/d3636025e8253c6144358ec0a62773cae588395b",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+                "php": "^7.1.3"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/event-dispatcher-implementation": "",
+                "symfony/http-client-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
+                    "Symfony\\Contracts\\": ""
                 },
                 "exclude-from-classmap": [
-                    "/Tests/"
+                    "**/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2153,40 +2015,48 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "A set of abstractions extracted out of the Symfony components",
             "homepage": "https://symfony.com",
-            "time": "2019-04-11T09:48:14+00:00"
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-04-27T14:29:50+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.27",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb"
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/acf99758b1df8e9295e6b85aa69f294565c9fedb",
-                "reference": "acf99758b1df8e9295e6b85aa69f294565c9fedb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2213,29 +2083,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-04T21:34:32+00:00"
+            "time": "2019-02-07T11:40:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.27",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "61af5ce0b34b942d414fe8f1b11950d0e9a90e98"
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/61af5ce0b34b942d414fe8f1b11950d0e9a90e98",
-                "reference": "61af5ce0b34b942d414fe8f1b11950d0e9a90e98",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e45135658bd6c14b61850bf131c4f09a55133f69",
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2262,7 +2132,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-02T19:54:57+00:00"
+            "time": "2019-04-06T13:51:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2383,25 +2253,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.27",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "a9c4dfbf653023b668c282e4e02609d131f4057a"
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/a9c4dfbf653023b668c282e4e02609d131f4057a",
-                "reference": "a9c4dfbf653023b668c282e4e02609d131f4057a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8cf39fb4ccff793340c258ee7760fd40bfe745fe",
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2428,24 +2298,24 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-08T16:15:54+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.27",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "6712daf03ee25b53abb14e7e8e0ede1a770efdb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/6712daf03ee25b53abb14e7e8e0ede1a770efdb1",
+                "reference": "6712daf03ee25b53abb14e7e8e0ede1a770efdb1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -2460,7 +2330,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2487,47 +2357,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-04-04T09:56:43+00:00"
+            "time": "2019-03-30T15:58:42+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2589,11 +2419,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.8",
+        "php": ">=5.6",
         "composer-plugin-api": "^1.0.0"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.0.8"
-    }
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "013ed623b077c25b2fbc4eb109730cd1",
+    "content-hash": "5acbedb2bb5d9191dfe035fd653e93a8",
     "packages": [],
     "packages-dev": [
         {
@@ -69,12 +69,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "dd40d74bf6041ddcefa1ebe46fb9117d031b1ccd"
+                "reference": "d63bf33848f396c58c5e0de834cf15f9d7094b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/dd40d74bf6041ddcefa1ebe46fb9117d031b1ccd",
-                "reference": "dd40d74bf6041ddcefa1ebe46fb9117d031b1ccd",
+                "url": "https://api.github.com/repos/composer/composer/zipball/d63bf33848f396c58c5e0de834cf15f9d7094b95",
+                "reference": "d63bf33848f396c58c5e0de834cf15f9d7094b95",
                 "shasum": ""
             },
             "require": {
@@ -141,7 +141,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-04-10T11:11:57+00:00"
+            "time": "2019-05-14T08:30:18+00:00"
         },
         {
             "name": "composer/semver",
@@ -735,16 +735,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -782,7 +782,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2039,7 +2039,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -2111,7 +2111,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -2167,7 +2167,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -2217,7 +2217,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2383,7 +2383,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -2432,7 +2432,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/AllowedPackages.php
+++ b/src/AllowedPackages.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\Composer;
@@ -17,18 +15,14 @@ use Grasmash\ComposerScaffold\ScaffoldFilePath;
  * drupal/assets, then the later package will also implicitly be allowed.
  */
 class AllowedPackages {
-
   /**
    * The Composer service.
    *
    * @var \Composer\Composer
    */
   protected $composer;
-
   protected $io;
-
   protected $manageOptions;
-
   protected $newPackages;
 
   /**
@@ -59,10 +53,9 @@ class AllowedPackages {
    * @return \Composer\Package\PackageInterface[]
    *   An array of allowed Composer packages.
    */
-  public function getAllowedPackages(): array {
+  public function getAllowedPackages() {
     $options = $this->manageOptions->getOptions();
     $allowed_packages = $this->recursiveGetAllowedPackages($options->allowedPackages());
-
     // If the root package defines any file mappings, then implicitly add it
     // to the list of allowed packages. Add it at the end so that it overrides
     // all the preceding packages.
@@ -71,10 +64,8 @@ class AllowedPackages {
       unset($allowed_packages[$root_package->getName()]);
       $allowed_packages[$root_package->getName()] = $root_package;
     }
-
     // Handle any newly-added packages that are not already allowed.
     $allowed_packages = $this->evaluateNewPackages($allowed_packages);
-
     return $allowed_packages;
   }
 
@@ -89,12 +80,11 @@ class AllowedPackages {
    * @return \Composer\Package\PackageInterface[]
    *   Mapping of package names to PackageInterface in priority order.
    */
-  protected function recursiveGetAllowedPackages(array $packages_to_allow, array $allowed_packages = []) : array {
+  protected function recursiveGetAllowedPackages(array $packages_to_allow, array $allowed_packages = []) {
     foreach ($packages_to_allow as $name) {
       $package = $this->getPackage($name);
       if ($package && $package instanceof PackageInterface && !array_key_exists($name, $allowed_packages)) {
         $allowed_packages[$name] = $package;
-
         $packageOptions = $this->manageOptions->packageOptions($package);
         $allowed_packages = $this->recursiveGetAllowedPackages($packageOptions->allowedPackages(), $allowed_packages);
       }
@@ -116,13 +106,12 @@ class AllowedPackages {
   protected function evaluateNewPackages(array $allowed_packages) {
     foreach ($this->newPackages as $name => $newPackage) {
       if (!array_key_exists($name, $allowed_packages)) {
-        $this->io->write("Package <comment>$name</comment> has scaffold operations, but it is not allowed in the root-level composer.json file.");
+        $this->io->write("Package <comment>{$name}</comment> has scaffold operations, but it is not allowed in the root-level composer.json file.");
       }
       else {
-        $this->io->write("Package <comment>$name</comment> has scaffold operations, and is already allowed in the root-level composer.json file.");
+        $this->io->write("Package <comment>{$name}</comment> has scaffold operations, and is already allowed in the root-level composer.json file.");
       }
     }
-
     // In the future, we will allow this method to add more allowed packages.
     return $allowed_packages;
   }
@@ -136,7 +125,7 @@ class AllowedPackages {
    * @return \Composer\Package\PackageInterface|null
    *   The Composer package.
    */
-  protected function getPackage(string $name) {
+  protected function getPackage($name) {
     return $this->composer->getRepositoryManager()->getLocalRepository()->findPackage($name, '*');
   }
 

--- a/src/CommandProvider.php
+++ b/src/CommandProvider.php
@@ -13,9 +13,7 @@ class CommandProvider implements CommandProviderCapability {
    * {@inheritdoc}
    */
   public function getCommands() {
-    return [
-      new ComposerScaffoldCommand(),
-    ];
+    return [new ComposerScaffoldCommand()];
   }
 
 }

--- a/src/ComposerScaffoldCommand.php
+++ b/src/ComposerScaffoldCommand.php
@@ -18,9 +18,7 @@ class ComposerScaffoldCommand extends BaseCommand {
    */
   protected function configure() {
     parent::configure();
-    $this
-      ->setName('composer:scaffold')
-      ->setDescription('Update the Composer scaffold files.');
+    $this->setName('composer:scaffold')->setDescription('Update the Composer scaffold files.');
   }
 
   /**

--- a/src/DetectAddingPackagesWithScaffolding.php
+++ b/src/DetectAddingPackagesWithScaffolding.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\Installer\PackageEvent;
@@ -14,7 +12,6 @@ use Composer\Installer\PackageEvent;
  * contain scaffolding instructions.
  */
 class DetectAddingPackagesWithScaffolding {
-
   protected $manageAllowedPackages;
 
   /**
@@ -37,12 +34,8 @@ class DetectAddingPackagesWithScaffolding {
     $operation = $event->getOperation();
     $jobType = $operation->getJobType();
     $reason = $operation->getReason();
-
     // Get the package.
-    $package = ($operation->getJobType() == 'update') ?
-      $operation->getTargetPackage() :
-      $operation->getPackage();
-
+    $package = $operation->getJobType() == 'update' ? $operation->getTargetPackage() : $operation->getPackage();
     if (ScaffoldOptions::hasOptions($package->getExtra())) {
       $this->manageAllowedPackages->addedPackageWithScaffolding($package);
     }

--- a/src/GenerateAutoloadReferenceFile.php
+++ b/src/GenerateAutoloadReferenceFile.php
@@ -11,7 +11,6 @@ use Grasmash\ComposerScaffold\Operations\ScaffoldResult;
  * Generates an 'autoload.php' that includes the autoloader created by Composer.
  */
 class GenerateAutoloadReferenceFile {
-
   protected $vendorPath;
 
   /**
@@ -20,7 +19,7 @@ class GenerateAutoloadReferenceFile {
    * @param string $vendorPath
    *   Path to the vendor directory.
    */
-  public function __construct(string $vendorPath) {
+  public function __construct($vendorPath) {
     $this->vendorPath = $vendorPath;
   }
 
@@ -37,15 +36,13 @@ class GenerateAutoloadReferenceFile {
    * @return \Grasmash\ComposerScaffold\Operations\ScaffoldResult
    *   The result of the autoload file generation
    */
-  public function generateAutoload(ScaffoldFilePath $autoloadPath) : ScaffoldResult {
+  public function generateAutoload(ScaffoldFilePath $autoloadPath) {
     $location = dirname($autoloadPath->fullPath());
     // Calculate the relative path from the webroot (location of the project
     // autoload.php) to the vendor directory.
     $fs = new SymfonyFilesystem();
     $relativeVendorPath = $fs->makePathRelative($this->vendorPath, realpath($location));
-
     $fs->dumpFile($autoloadPath->fullPath(), $this->autoLoadContents($relativeVendorPath));
-
     return (new ScaffoldResult($autoloadPath))->setManaged();
   }
 
@@ -55,9 +52,8 @@ class GenerateAutoloadReferenceFile {
    * @return string
    *   Return the contents for the autoload.php.
    */
-  protected function autoLoadContents(string $relativeVendorPath) : string {
+  protected function autoLoadContents($relativeVendorPath) {
     $relativeVendorPath = rtrim($relativeVendorPath, '/');
-
     return <<<EOF
 <?php
 
@@ -74,7 +70,7 @@ class GenerateAutoloadReferenceFile {
  * @see core/modules/statistics/statistics.php
  */
 
-return require __DIR__ . '/$relativeVendorPath/autoload.php';
+return require __DIR__ . '/{$relativeVendorPath}/autoload.php';
 
 EOF;
   }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\Composer;
@@ -22,28 +20,22 @@ use Grasmash\ComposerScaffold\Operations\OperationInterface;
  * Contains the primary logic which determines the files to be fetched and processed.
  */
 class Handler {
-
   const PRE_COMPOSER_SCAFFOLD_CMD = 'pre-composer-scaffold-cmd';
   const POST_COMPOSER_SCAFFOLD_CMD = 'post-composer-scaffold-cmd';
-
   /**
    * The Composer service.
    *
    * @var \Composer\Composer
    */
   protected $composer;
-
   /**
    * Composer's I/O service.
    *
    * @var \Composer\IO\IOInterface
    */
   protected $io;
-
   protected $manageOptions;
-
   protected $manageAllowedPackages;
-
   protected $postPackageListeners;
 
   /**
@@ -109,9 +101,8 @@ class Handler {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface[]
    *   An array of destination paths => scaffold operation objects.
    */
-  public function getPackageFileMappings(PackageInterface $package) : array {
+  public function getPackageFileMappings(PackageInterface $package) {
     $options = $this->manageOptions->packageOptions($package);
-
     if ($options->hasFileMapping()) {
       return $this->createScaffoldOperations($package, $options->fileMapping());
     }
@@ -134,16 +125,14 @@ class Handler {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface[]
    *   A list of scaffolding operation objects
    */
-  protected function createScaffoldOperations(PackageInterface $package, array $package_file_mappings) : array {
+  protected function createScaffoldOperations(PackageInterface $package, array $package_file_mappings) {
     $options = $this->manageOptions->getOptions();
     $scaffoldOpFactory = new OperationFactory($this->composer);
     $scaffoldOps = [];
-
     foreach ($package_file_mappings as $key => $value) {
       $metadata = $scaffoldOpFactory->normalizeScaffoldMetadata($key, $value);
       $scaffoldOps[$key] = $scaffoldOpFactory->createScaffoldOp($package, $key, $metadata, $options);
     }
-
     return $scaffoldOps;
   }
 
@@ -158,34 +147,27 @@ class Handler {
     if (empty($allowedPackages)) {
       return;
     }
-
     // Call any pre-scaffold scripts that may be defined.
     $dispatcher = new EventDispatcher($this->composer, $this->io);
     $dispatcher->dispatch(self::PRE_COMPOSER_SCAFFOLD_CMD);
-
     // Fetch the list of file mappings from each allowed package and
     // normalize them.
     $file_mappings = $this->getFileMappingsFromPackages($allowedPackages);
-
     // Analyze the list of file mappings, and determine which take priority.
     $scaffoldCollection = new OperationCollection($this->io);
     $locationReplacements = $this->manageOptions->getLocationReplacements();
     $scaffoldCollection->coalateScaffoldFiles($file_mappings, $locationReplacements);
-
     // Write the collected scaffold files to the designated location on disk.
     $scaffoldResults = $scaffoldCollection->processScaffoldFiles($this->manageOptions->getOptions());
-
     // Generate an autoload file in the document root that includes
     // the autoload.php file in the vendor directory, wherever that is.
     // Drupal requires this in order to easily locate relocated vendor dirs.
     $autoloadPath = ScaffoldFilePath::autoloadPath($this->rootPackageName(), $this->getWebRoot());
     $generator = new GenerateAutoloadReferenceFile($this->getVendorPath());
     $scaffoldResults[] = $generator->generateAutoload($autoloadPath);
-
     // Add the managed scaffold files to .gitignore if applicable.
     $manager = new ManageGitIgnore(getcwd());
     $manager->manageIgnored($scaffoldResults, $this->manageOptions->getOptions());
-
     // Call post-scaffold scripts.
     $dispatcher->dispatch(self::POST_COMPOSER_SCAFFOLD_CMD);
   }
@@ -200,11 +182,8 @@ class Handler {
    *
    * @throws \Exception
    */
-  public function getWebRoot() : string {
-    return $this->manageOptions->getOptions()->requiredLocation(
-      'web-root',
-      "The extra.composer-scaffold.location.web-root is not set in composer.json."
-    );
+  public function getWebRoot() {
+    return $this->manageOptions->getOptions()->requiredLocation('web-root', "The extra.composer-scaffold.location.web-root is not set in composer.json.");
   }
 
   /**
@@ -213,7 +192,7 @@ class Handler {
    * @return string
    *   The file path of the vendor directory.
    */
-  public function getVendorPath() : string {
+  public function getVendorPath() {
     $vendorDir = $this->composer->getConfig()->get('vendor-dir');
     $filesystem = new Filesystem();
     $filesystem->ensureDirectoryExists($vendorDir);
@@ -230,7 +209,7 @@ class Handler {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface[]
    *   An array of destination paths => scaffold operation objects.
    */
-  protected function getFileMappingsFromPackages(array $allowed_packages) : array {
+  protected function getFileMappingsFromPackages(array $allowed_packages) {
     $file_mappings = [];
     foreach ($allowed_packages as $package_name => $package) {
       $package_file_mappings = $this->getPackageFileMappings($package);
@@ -245,7 +224,7 @@ class Handler {
    * @return string
    *   The package name of the root project
    */
-  protected function rootPackageName() : string {
+  protected function rootPackageName() {
     $root_package = $this->composer->getPackage();
     return $root_package->getName();
   }

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 /**
@@ -20,7 +18,7 @@ class Interpolator {
    * @param string $endToken
    *   The end marker for a token, e.g. ']'.
    */
-  public function __construct(string $startToken = '\[', string $endToken = '\]') {
+  public function __construct($startToken = '\\[', $endToken = '\\]') {
     $this->startToken = $startToken;
     $this->endToken = $endToken;
     $this->data = [];
@@ -71,7 +69,7 @@ class Interpolator {
    * @return string
    *   The message after replacements have been made.
    */
-  public function interpolate(string $message, $extra = [], $default = '') : string {
+  public function interpolate($message, $extra = [], $default = '') {
     $data = $extra + $this->data;
     $replacements = $this->replacements($message, $data, $default);
     return strtr($message, $replacements);
@@ -86,13 +84,11 @@ class Interpolator {
    * @return string[]
    *   map of token to key, e.g. {{key}} => key
    */
-  public function findTokens(string $message) : array {
+  public function findTokens($message) {
     $regEx = '#' . $this->startToken . '([a-zA-Z0-9._-]+)' . $this->endToken . '#';
-
     if (!preg_match_all($regEx, $message, $matches, PREG_SET_ORDER)) {
       return [];
     }
-
     $tokens = [];
     foreach ($matches as $matchSet) {
       list($sourceText, $key) = $matchSet;
@@ -108,9 +104,8 @@ class Interpolator {
    * keys from the provided message. Keys that do not exist in the configuration
    * are replaced with the default value.
    */
-  protected function replacements(string $message, $data, $default = '') : array {
+  protected function replacements($message, $data, $default = '') {
     $tokens = $this->findTokens($message);
-
     $replacements = [];
     foreach ($tokens as $sourceText => $key) {
       $replacementText = $this->get($key, $data, $default);
@@ -124,7 +119,7 @@ class Interpolator {
   /**
    * Get a value from an array.
    */
-  protected function get(string $key, $data, $default) {
+  protected function get($key, $data, $default) {
     return array_key_exists($key, $data) ? $data[$key] : $default;
   }
 

--- a/src/ManageGitIgnore.php
+++ b/src/ManageGitIgnore.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Symfony\Component\Process\Process;
@@ -10,7 +8,6 @@ use Symfony\Component\Process\Process;
  * Manage the .gitignore file.
  */
 class ManageGitIgnore {
-
   protected $dir;
 
   /**
@@ -19,7 +16,7 @@ class ManageGitIgnore {
    * @param string $dir
    *   The directory where the project is located.
    */
-  public function __construct(string $dir) {
+  public function __construct($dir) {
     $this->dir = $dir;
   }
 
@@ -32,11 +29,10 @@ class ManageGitIgnore {
    * @return bool
    *   Whether the specified file is already ignored or not (TRUE if ignored).
    */
-  public function checkIgnore(string $path) {
+  public function checkIgnore($path) {
     $process = new Process('git check-ignore ' . $path, $this->dir);
     $process->run();
-    $isIgnored = ($process->getExitCode() == 0);
-
+    $isIgnored = $process->getExitCode() == 0;
     return $isIgnored;
   }
 
@@ -49,11 +45,10 @@ class ManageGitIgnore {
    * @return bool
    *   Whether the specified file is already tracked or not (TRUE if tracked).
    */
-  public function checkTracked(string $path) {
+  public function checkTracked($path) {
     $process = new Process('git ls-files --error-unmatch ' . $path, $this->dir);
     $process->run();
-    $isTracked = ($process->getExitCode() == 0);
-
+    $isTracked = $process->getExitCode() == 0;
     return $isTracked;
   }
 
@@ -66,8 +61,7 @@ class ManageGitIgnore {
   public function isRepository() {
     $process = new Process('git rev-parse --show-toplevel', $this->dir);
     $process->run();
-    $isRepository = ($process->getExitCode() == 0);
-
+    $isRepository = $process->getExitCode() == 0;
     return $isRepository;
   }
 
@@ -145,11 +139,9 @@ class ManageGitIgnore {
    * @param string[] $entries
    *   Entries to write to .gitignore file.
    */
-  public function addToGitIgnore(string $dir, array $entries) {
+  public function addToGitIgnore($dir, array $entries) {
     sort($entries);
-
     $gitIgnorePath = $dir . '/.gitignore';
-
     $contents = $this->gitIgnoreContents($gitIgnorePath);
     $contents .= implode("\n", $entries);
     file_put_contents($gitIgnorePath, $contents);
@@ -169,7 +161,7 @@ class ManageGitIgnore {
       return '';
     }
     $contents = file_get_contents($gitIgnorePath);
-    if (!empty($contents) && (substr($contents, -1) != "\n")) {
+    if (!empty($contents) && substr($contents, -1) != "\n") {
       $contents .= "\n";
     }
     return $contents;

--- a/src/ManageOptions.php
+++ b/src/ManageOptions.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\Composer;
@@ -19,7 +17,6 @@ use Grasmash\ComposerScaffold\ScaffoldFilePath;
  * section of the project data.
  */
 class ManageOptions {
-
   /**
    * The Composer service.
    *
@@ -40,7 +37,7 @@ class ManageOptions {
    * @return ScaffoldOptions
    *   The scaffold otpions object
    */
-  public function getOptions() : ScaffoldOptions {
+  public function getOptions() {
     return $this->packageOptions($this->composer->getPackage());
   }
 
@@ -53,7 +50,7 @@ class ManageOptions {
    * @return ScaffoldOptions
    *   The scaffold otpions object
    */
-  public function packageOptions(PackageInterface $package) : ScaffoldOptions {
+  public function packageOptions(PackageInterface $package) {
     return ScaffoldOptions::create($package->getExtra());
   }
 
@@ -68,7 +65,7 @@ class ManageOptions {
    * @return Interpolator
    *   Object that will do replacements in a string using tokens in 'locations' element.
    */
-  public function getLocationReplacements() : Interpolator {
+  public function getLocationReplacements() {
     return (new Interpolator())->setData($this->ensureLocations());
   }
 
@@ -77,17 +74,14 @@ class ManageOptions {
    *
    * Create them on the filesystem if they do not.
    */
-  public function ensureLocations() : array {
+  public function ensureLocations() {
     $fs = new Filesystem();
     $locations = $this->getOptions()->locations() + ['web_root' => './'];
-    $locations = array_map(
-      function ($location) use ($fs) {
-        $fs->ensureDirectoryExists($location);
-        $location = realpath($location);
-        return $location;
-      },
-      $locations
-    );
+    $locations = array_map(function ($location) use ($fs) {
+      $fs->ensureDirectoryExists($location);
+      $location = realpath($location);
+      return $location;
+    }, $locations);
     return $locations;
   }
 

--- a/src/Operations/AppendOp.php
+++ b/src/Operations/AppendOp.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\Composer;
@@ -16,9 +14,7 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
  * Scaffold operation to add to the beginning and/or end of a scaffold file.
  */
 class AppendOp implements OperationInterface, OriginalOpAwareInterface {
-
   use OriginalOpAwareTrait;
-
   protected $prepend;
   protected $append;
 
@@ -30,7 +26,7 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
    *
    * @return $this
    */
-  public function setPrependFile(ScaffoldFilePath $prependPath) : self {
+  public function setPrependFile(ScaffoldFilePath $prependPath) {
     $this->prepend = $prependPath;
     return $this;
   }
@@ -43,7 +39,7 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
    *
    * @return $this
    */
-  public function setAppendFile(ScaffoldFilePath $appendPath) : self {
+  public function setAppendFile(ScaffoldFilePath $appendPath) {
     $this->append = $appendPath;
     return $this;
   }
@@ -68,36 +64,31 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
     $interpolator = $destination->getInterpolator();
     $this->addInterpolationData($interpolator);
     $destination_path = $destination->fullPath();
-
     // It is not possible to append / prepend unless the destination path
     // is the same as some scaffold file provided by an earlier package.
     if (!$this->hasOriginalOp()) {
       throw new \Exception($interpolator->interpolate("Cannot append/prepend because no prior package provided a scaffold file at that [dest-rel-path]."));
     }
-
     // First, scaffold the original file. Disable symlinking, because we
     // need a copy of the file if we're going to append / prepend to it.
     @unlink($destination_path);
     $this->originalOp()->process($destination, $io, $options->overrideSymlink(FALSE));
-
     // Fetch the prepend contents, if provided.
     $prependContents = '';
     if (!empty($this->prepend)) {
       $prependContents = file_get_contents($this->prepend->fullPath()) . "\n";
       $io->write($interpolator->interpolate("  - Prepend to <info>[dest-rel-path]</info> from <info>[prepend-rel-path]</info>"));
     }
-
     // Fetch the append contents, if provided.
     $appendContents = '';
     if (!empty($this->append)) {
       $appendContents = "\n" . file_get_contents($this->append->fullPath());
       $io->write($interpolator->interpolate("  - Append to <info>[dest-rel-path]</info> from <info>[append-rel-path]</info>"));
     }
-
     $this->append($destination, $prependContents, $appendContents);
     return (new ScaffoldResult($destination))->setManaged();
   }
@@ -112,22 +103,19 @@ class AppendOp implements OperationInterface, OriginalOpAwareInterface {
    * @param string $appendContents
    *   The contents to add to the end of the file.
    */
-  protected function append(ScaffoldFilePath $destination, string $prependContents, string $appendContents) {
+  protected function append(ScaffoldFilePath $destination, $prependContents, $appendContents) {
     $interpolator = $destination->getInterpolator();
     $destination_path = $destination->fullPath();
-
     // Exit early if there is no append / prepend data.
     if (empty(trim($prependContents)) && empty(trim($appendContents))) {
       $io->write($interpolator->interpolate("  - Keep <info>[dest-rel-path]</info> unchanged: no content to prepend / append was provided."));
       return;
     }
-
     // We're going to assume that none of these files are going to be
     // very large, so we will just load them all into memory for now.
     // We'd want to use streaminig if we thought that anyone would scaffold
     // and append very large files.
     $originalContents = file_get_contents($destination_path);
-
     // Write the appended / prepended contents back to the file.
     $alteredContents = $prependContents . $originalContents . $appendContents;
     file_put_contents($destination_path, $alteredContents);

--- a/src/Operations/OperationCollection.php
+++ b/src/Operations/OperationCollection.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
@@ -14,7 +12,6 @@ use Grasmash\ComposerScaffold\ScaffoldOptions;
  * OperationCollection keeps track of the collection of files to be scaffolded.
  */
 class OperationCollection {
-
   protected $listOfScaffoldFiles;
   protected $resolvedFileMappings;
   protected $io;
@@ -36,7 +33,7 @@ class OperationCollection {
    * @return array
    *   Associative array containing package name => file mappings
    */
-  public function fileMappings() : array {
+  public function fileMappings() {
     return $this->resolvedFileMappings;
   }
 
@@ -46,7 +43,7 @@ class OperationCollection {
    * @return array
    *   Associative array containing destination => operation mappings
    */
-  public function scaffoldList() : array {
+  public function scaffoldList() {
     return $this->listOfScaffoldFiles;
   }
 
@@ -65,7 +62,7 @@ class OperationCollection {
    * @return string
    *   The name of the package that provided the scaffold file information.
    */
-  public function findProvidingPackage(ScaffoldFileInfo $scaffold_file): string {
+  public function findProvidingPackage(ScaffoldFileInfo $scaffold_file) {
     // The scaffold file should always be in our list, but we will check
     // just to be sure that it really is.
     $scaffoldList = $this->scaffoldList();
@@ -92,19 +89,13 @@ class OperationCollection {
     $list_of_scaffold_files = [];
     foreach ($file_mappings as $package_name => $package_file_mappings) {
       foreach ($package_file_mappings as $destination_rel_path => $op) {
-
         $destination = ScaffoldFilePath::destinationPath($package_name, $destination_rel_path, $locationReplacements);
-
-        $scaffold_file = (new ScaffoldFileInfo())
-          ->setDestination($destination)
-          ->setOp($op);
-
+        $scaffold_file = (new ScaffoldFileInfo())->setDestination($destination)->setOp($op);
         // If there was already a scaffolding operation happening at this
         // path, then pass it along to the new scaffold op, if it cares.
-        if (isset($list_of_scaffold_files[$destination_rel_path]) && ($op instanceof OriginalOpAwareInterface)) {
+        if (isset($list_of_scaffold_files[$destination_rel_path]) && $op instanceof OriginalOpAwareInterface) {
           $op->setOriginalOp($list_of_scaffold_files[$destination_rel_path]->op());
         }
-
         $list_of_scaffold_files[$destination_rel_path] = $scaffold_file;
         $resolved_file_mappings[$package_name][$destination_rel_path] = $scaffold_file;
       }
@@ -131,11 +122,11 @@ class OperationCollection {
     // those not being scaffolded (because they were overridden or removed
     // by some later package).
     foreach ($this->fileMappings() as $package_name => $package_scaffold_files) {
-      $this->io->write("Scaffolding files for <comment>$package_name</comment>:");
+      $this->io->write("Scaffolding files for <comment>{$package_name}</comment>:");
       foreach ($package_scaffold_files as $dest_rel_path => $scaffold_file) {
         $overriding_package = $this->findProvidingPackage($scaffold_file);
         if ($scaffold_file->overridden($overriding_package)) {
-          $this->io->write($scaffold_file->interpolate("  - Skip <info>[dest-rel-path]</info>: overridden in <comment>$overriding_package</comment>"));
+          $this->io->write($scaffold_file->interpolate("  - Skip <info>[dest-rel-path]</info>: overridden in <comment>{$overriding_package}</comment>"));
         }
         else {
           $result[$dest_rel_path] = $scaffold_file->process($this->io, $options);

--- a/src/Operations/OperationFactory.php
+++ b/src/Operations/OperationFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\Composer;
@@ -15,7 +13,6 @@ use Grasmash\ComposerScaffold\ScaffoldOptions;
  * Create Scaffold operation objects based on provided metadata.
  */
 class OperationFactory {
-
   protected $composer;
 
   /**
@@ -45,25 +42,22 @@ class OperationFactory {
    * @return array
    *   Normalized scaffold metadata.
    */
-  public function normalizeScaffoldMetadata(string $key, $value) : array {
+  public function normalizeScaffoldMetadata($key, $value) {
     if (is_bool($value)) {
       if (!$value) {
         return ['mode' => 'skip'];
       }
-      throw new \Exception("File mapping $key cannot be given the value 'true'.");
+      throw new \Exception("File mapping {$key} cannot be given the value 'true'.");
     }
     if (empty($value)) {
-      throw new \Exception("File mapping $key cannot be empty.");
+      throw new \Exception("File mapping {$key} cannot be empty.");
     }
     if (is_string($value)) {
       $value = ['path' => $value];
     }
     // If there is no 'mode', but there is an 'append' or a 'prepend' path,
     // then the mode is 'append' (append + prepend).
-    if (
-      !isset($value['mode']) &&
-      (isset($value['append']) || isset($value['prepend']))
-    ) {
+    if (!isset($value['mode']) && (isset($value['append']) || isset($value['prepend']))) {
       $value['mode'] = 'append';
     }
     // If there is no 'mode', then the default is 'replace'.
@@ -88,7 +82,7 @@ class OperationFactory {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   The scaffolding operation object (skip, replace, etc.)
    */
-  public function createScaffoldOp(PackageInterface $package, $dest_rel_path, $value, ScaffoldOptions $options) : OperationInterface {
+  public function createScaffoldOp(PackageInterface $package, $dest_rel_path, $value, ScaffoldOptions $options) {
     switch ($value['mode']) {
       case 'skip':
         return new SkipOp();
@@ -99,7 +93,6 @@ class OperationFactory {
       case 'append':
         return $this->createAppendOp($package, $dest_rel_path, $value, $options);
     }
-
     throw new \Exception("Unknown scaffold opperation mode <comment>{$value['mode']}</comment>.");
   }
 
@@ -120,24 +113,17 @@ class OperationFactory {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   A scaffold replace operation obejct.
    */
-  protected function createReplaceOp(PackageInterface $package, string $dest_rel_path, array $metadata, ScaffoldOptions $options) : OperationInterface {
+  protected function createReplaceOp(PackageInterface $package, $dest_rel_path, array $metadata, ScaffoldOptions $options) {
     $op = new ReplaceOp();
-
     // If this op does not provide an 'overwrite' value, then fill in the default.
     $metadata += ['overwrite' => $options->overwrite()];
     if (!isset($metadata['path'])) {
       throw new \Exception("'path' component required for 'replace' operations.");
     }
-
     $package_name = $package->getName();
     $package_path = $this->getPackagePath($package);
-
     $source = ScaffoldFilePath::sourcePath($package_name, $package_path, $dest_rel_path, $metadata['path']);
-
-    $op
-      ->setSource($source)
-      ->setOverwrite($metadata['overwrite']);
-
+    $op->setSource($source)->setOverwrite($metadata['overwrite']);
     return $op;
   }
 
@@ -156,23 +142,18 @@ class OperationFactory {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   A scaffold replace operation obejct.
    */
-  protected function createAppendOp(PackageInterface $package, string $dest_rel_path, array $metadata, ScaffoldOptions $options) : OperationInterface {
-
+  protected function createAppendOp(PackageInterface $package, $dest_rel_path, array $metadata, ScaffoldOptions $options) {
     $op = new AppendOp();
-
     $package_name = $package->getName();
     $package_path = $this->getPackagePath($package);
-
     if (isset($metadata['prepend'])) {
       $prepend_source_file = ScaffoldFilePath::sourcePath($package_name, $package_path, $dest_rel_path, $metadata['prepend']);
       $op->setPrependFile($prepend_source_file);
     }
-
     if (isset($metadata['append'])) {
       $append_source_file = ScaffoldFilePath::sourcePath($package_name, $package_path, $dest_rel_path, $metadata['append']);
       $op->setAppendFile($append_source_file);
     }
-
     return $op;
   }
 
@@ -189,7 +170,7 @@ class OperationFactory {
    * @return string
    *   The file path.
    */
-  protected function getPackagePath(PackageInterface $package) : string {
+  protected function getPackagePath(PackageInterface $package) {
     if ($package->getName() == $this->composer->getPackage()->getName()) {
       // This will respect the --working-dir option if Composer is invoked with
       // it. There is no API or method to determine the filesystem path of

--- a/src/Operations/OperationInterface.php
+++ b/src/Operations/OperationInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
@@ -26,6 +24,6 @@ interface OperationInterface {
    * @return ScaffoldResult
    *   Result of the scaffolding operation (is this file managed or unmanaged, etc.)
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult;
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options);
 
 }

--- a/src/Operations/OriginalOpAwareInterface.php
+++ b/src/Operations/OriginalOpAwareInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 /**
@@ -25,7 +23,7 @@ interface OriginalOpAwareInterface {
    * @return bool
    *   Whether or not an original operation was provided.
    */
-  public function hasOriginalOp() : bool;
+  public function hasOriginalOp();
 
   /**
    * Return the original operation that this op is overriding.
@@ -33,6 +31,6 @@ interface OriginalOpAwareInterface {
    * @return OperationInterface
    *   The original operation.
    */
-  public function originalOp() : OperationInterface;
+  public function originalOp();
 
 }

--- a/src/Operations/OriginalOpAwareTrait.php
+++ b/src/Operations/OriginalOpAwareTrait.php
@@ -1,14 +1,11 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 /**
  * Use OriginalOpAwareTrait to be informed of any op at the same destination path.
  */
 trait OriginalOpAwareTrait {
-
   /**
    * The original operation at the same destination path.
    *
@@ -28,14 +25,14 @@ trait OriginalOpAwareTrait {
   /**
    * {@inheritdoc}
    */
-  public function hasOriginalOp() : bool {
+  public function hasOriginalOp() {
     return isset($this->originalOp);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function originalOp() : OperationInterface {
+  public function originalOp() {
     return $this->originalOp;
   }
 

--- a/src/Operations/ReplaceOp.php
+++ b/src/Operations/ReplaceOp.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\Composer;
@@ -15,7 +13,6 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
  * Scaffold operation to copy or symlink from source to destination.
  */
 class ReplaceOp implements OperationInterface {
-
   protected $source;
   protected $overwrite;
 
@@ -27,7 +24,7 @@ class ReplaceOp implements OperationInterface {
    *
    * @return $this
    */
-  public function setSource(ScaffoldFilePath $sourcePath) : self {
+  public function setSource(ScaffoldFilePath $sourcePath) {
     $this->source = $sourcePath;
     return $this;
   }
@@ -38,7 +35,7 @@ class ReplaceOp implements OperationInterface {
    * @return \Grasmash\ComposerScaffold\ScaffoldFilePath
    *   The source file reference object.
    */
-  public function getSource() : ScaffoldFilePath {
+  public function getSource() {
     return $this->source;
   }
 
@@ -50,7 +47,7 @@ class ReplaceOp implements OperationInterface {
    *
    * @return $this
    */
-  public function setOverwrite(bool $overwrite) : self {
+  public function setOverwrite($overwrite) {
     $this->overwrite = $overwrite;
     return $this;
   }
@@ -61,7 +58,7 @@ class ReplaceOp implements OperationInterface {
    * @return bool
    *   Value of the 'overwrite' option.
    */
-  public function getOverwrite() : bool {
+  public function getOverwrite() {
     return $this->overwrite;
   }
 
@@ -70,23 +67,19 @@ class ReplaceOp implements OperationInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
     $fs = new Filesystem();
-
     $destination_path = $destination->fullPath();
-
     // Do nothing if overwrite is 'false' and a file already exists at the destination.
-    if (($this->getOverwrite() === FALSE) && file_exists($destination_path)) {
+    if ($this->getOverwrite() === FALSE && file_exists($destination_path)) {
       $interpolator = $destination->getInterpolator();
       $io->write($interpolator->interpolate("  - Skip <info>[dest-rel-path]</info> because it already exists and overwrite is <comment>false</comment>."));
       return (new ScaffoldResult($destination))->setManaged(FALSE);
     }
-
     // Get rid of the destination if it exists, and make sure that
     // the directory where it's going to be placed exists.
     @unlink($destination_path);
     $fs->ensureDirectoryExists(dirname($destination_path));
-
     if ($options->symlink() == TRUE) {
       return $this->symlinkScaffold($destination, $io, $options);
     }
@@ -103,17 +96,14 @@ class ReplaceOp implements OperationInterface {
    * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Various options that may alter the behavior of the operation.
    */
-  public function copyScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
+  public function copyScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
     $interpolator = $destination->getInterpolator();
     $this->getSource()->addInterpolationData($interpolator);
-
     $success = copy($this->getSource()->fullPath(), $destination->fullPath());
     if (!$success) {
       throw new \Exception($interpolator->interpolate("Could not copy source file <info>[src-rel-path]</info> to <info>[dest-rel-path]</info>!"));
     }
-
     $io->write($interpolator->interpolate("  - Copy <info>[dest-rel-path]</info> from <info>[src-rel-path]</info>"));
-
     return (new ScaffoldResult($destination))->setManaged($this->getOverwrite());
   }
 
@@ -127,11 +117,10 @@ class ReplaceOp implements OperationInterface {
    * @param \Grasmash\ComposerScaffold\ScaffoldOptions $options
    *   Various options that may alter the behavior of the operation.
    */
-  public function symlinkScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
+  public function symlinkScaffold(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
     $interpolator = $destination->getInterpolator();
     $source_path = $this->getSource()->fullPath();
     $destination_path = $destination->fullPath();
-
     try {
       $fs = new Filesystem();
       $fs->relativeSymlink($this->getSource()->fullPath(), $destination->fullPath());
@@ -139,9 +128,7 @@ class ReplaceOp implements OperationInterface {
     catch (\Exception $e) {
       throw new \Exception($interpolator->interpolate("Could not symlink source file <info>[src-rel-path]</info> to <info>[dest-rel-path]</info>! "), 1, $e);
     }
-
     $io->write($interpolator->interpolate("  - Link <info>[dest-rel-path]</info> from <info>[src-rel-path]</info>"));
-
     return (new ScaffoldResult($destination))->setManaged($this->getOverwrite());
   }
 

--- a/src/Operations/ScaffoldResult.php
+++ b/src/Operations/ScaffoldResult.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Grasmash\ComposerScaffold\ScaffoldFilePath;
@@ -10,7 +8,6 @@ use Grasmash\ComposerScaffold\ScaffoldFilePath;
  * Record the result of a scaffold operation.
  */
 class ScaffoldResult {
-
   protected $destination;
   protected $managed;
 
@@ -31,7 +28,7 @@ class ScaffoldResult {
    * @return bool
    *   Whether the scaffold file was managed by this plugin (scaffolded) or not (skipped).
    */
-  public function isManaged() : bool {
+  public function isManaged() {
     return $this->managed;
   }
 
@@ -43,7 +40,7 @@ class ScaffoldResult {
    *
    * @return $this
    */
-  public function setManaged(bool $isManaged = TRUE) {
+  public function setManaged($isManaged = TRUE) {
     $this->managed = $isManaged;
     return $this;
   }
@@ -54,7 +51,7 @@ class ScaffoldResult {
    * @return \Grasmash\ComposerScaffold\ScaffoldFilePath
    *   The destination path for the scaffold result.
    */
-  public function destination() : ScaffoldFilePath {
+  public function destination() {
     return $this->destination;
   }
 

--- a/src/Operations/SkipOp.php
+++ b/src/Operations/SkipOp.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold\Operations;
 
 use Composer\IO\IOInterface;
@@ -18,10 +16,9 @@ class SkipOp implements OperationInterface {
    *
    * {@inheritdoc}
    */
-  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) : ScaffoldResult {
+  public function process(ScaffoldFilePath $destination, IOInterface $io, ScaffoldOptions $options) {
     $interpolator = $destination->getInterpolator();
     $io->write($interpolator->interpolate("  - Skip <info>[dest-rel-path]</info>: disabled"));
-
     return (new ScaffoldResult($destination))->setManaged(FALSE);
   }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,7 +18,6 @@ use Composer\Plugin\CommandEvent;
  * Composer plugin for handling drupal scaffold.
  */
 class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
-
   /**
    * The Composer Scaffold handler.
    *
@@ -41,20 +40,14 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
    * {@inheritdoc}
    */
   public function getCapabilities() {
-    return [
-      'Composer\Plugin\Capability\CommandProvider' => 'Grasmash\ComposerScaffold\CommandProvider',
-    ];
+    return ['Composer\\Plugin\\Capability\\CommandProvider' => 'Grasmash\\ComposerScaffold\\CommandProvider'];
   }
 
   /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    return [
-      ScriptEvents::POST_UPDATE_CMD => 'postCmd',
-      PackageEvents::POST_PACKAGE_INSTALL => 'postPackage',
-      PluginEvents::COMMAND => 'onCommand',
-    ];
+    return [ScriptEvents::POST_UPDATE_CMD => 'postCmd', PackageEvents::POST_PACKAGE_INSTALL => 'postPackage', PluginEvents::COMMAND => 'onCommand'];
   }
 
   /**

--- a/src/ScaffoldFileInfo.php
+++ b/src/ScaffoldFileInfo.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\IO\IOInterface;
@@ -18,7 +16,6 @@ use Grasmash\ComposerScaffold\ScaffoldFilePath;
  * source files.
  */
 class ScaffoldFileInfo {
-
   protected $destination;
   protected $op;
 
@@ -30,7 +27,7 @@ class ScaffoldFileInfo {
    *
    * @return $this
    */
-  public function setOp(OperationInterface $op) : self {
+  public function setOp(OperationInterface $op) {
     $this->op = $op;
     return $this;
   }
@@ -41,7 +38,7 @@ class ScaffoldFileInfo {
    * @return \Grasmash\ComposerScaffold\Operations\OperationInterface
    *   Operations object that handles scaffolding (copy, make symlink, etc).
    */
-  public function op() : OperationInterface {
+  public function op() {
     return $this->op;
   }
 
@@ -51,7 +48,7 @@ class ScaffoldFileInfo {
    * @return string
    *   The name of the package this scaffold file info was collected from.
    */
-  public function packageName() : string {
+  public function packageName() {
     return $this->destination->packageName();
   }
 
@@ -63,7 +60,7 @@ class ScaffoldFileInfo {
    *
    * @return $this
    */
-  public function setDestination(ScaffoldFilePath $destination) : self {
+  public function setDestination(ScaffoldFilePath $destination) {
     $this->destination = $destination;
     return $this;
   }
@@ -74,7 +71,7 @@ class ScaffoldFileInfo {
    * @return \Grasmash\ComposerScaffold\ScaffoldFilePath
    *   The scaffold path to the destination file.
    */
-  public function destination() : ScaffoldFilePath {
+  public function destination() {
     return $this->destination;
   }
 
@@ -88,7 +85,7 @@ class ScaffoldFileInfo {
    * @return bool
    *   Whether this scaffold file if overridden or removed.
    */
-  public function overridden(string $providing_package) : bool {
+  public function overridden($providing_package) {
     return $this->packageName() !== $providing_package;
   }
 
@@ -98,7 +95,7 @@ class ScaffoldFileInfo {
    * @return Interpolator
    *   An interpolator for making string replacements.
    */
-  public function getInterpolator() : Interpolator {
+  public function getInterpolator() {
     return $this->destination->getInterpolator();
   }
 
@@ -115,7 +112,7 @@ class ScaffoldFileInfo {
    * @return string
    *   Interpolated string with placeholders replaced.
    */
-  public function interpolate(string $message, array $extra = [], $default = FALSE) : string {
+  public function interpolate($message, array $extra = [], $default = FALSE) {
     $interpolator = $this->getInterpolator();
     return $interpolator->interpolate($message, $extra, $default);
   }

--- a/src/ScaffoldFilePath.php
+++ b/src/ScaffoldFilePath.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Grasmash\ComposerScaffold\Interpolator;
@@ -20,7 +18,6 @@ use Grasmash\ComposerScaffold\Interpolator;
  * ScafoldFilePath objects.
  */
 class ScaffoldFilePath {
-
   protected $type;
   protected $packageName;
   protected $relPath;
@@ -38,7 +35,7 @@ class ScaffoldFilePath {
    * @param string $full_path
    *   The full path to the file.
    */
-  public function __construct(string $path_type, string $package_name, string $rel_path, string $full_path) {
+  public function __construct($path_type, $package_name, $rel_path, $full_path) {
     $this->type = $path_type;
     $this->packageName = $package_name;
     $this->relPath = $rel_path;
@@ -51,7 +48,7 @@ class ScaffoldFilePath {
    * @return string
    *   Name of package.
    */
-  public function packageName() : string {
+  public function packageName() {
     return $this->packageName;
   }
 
@@ -61,7 +58,7 @@ class ScaffoldFilePath {
    * @return string
    *   Relative path to file.
    */
-  public function relativePath() : string {
+  public function relativePath() {
     return $this->relPath;
   }
 
@@ -71,7 +68,7 @@ class ScaffoldFilePath {
    * @return string
    *   Full path to file.
    */
-  public function fullPath() : string {
+  public function fullPath() {
     return $this->fullPath;
   }
 
@@ -92,22 +89,19 @@ class ScaffoldFilePath {
    * @return self
    *   Object wrapping the relative and absolute path to the source file.
    */
-  public static function sourcePath(string $package_name, string $package_path, string $destination, string $source) : self {
+  public static function sourcePath($package_name, $package_path, $destination, $source) {
     // Complain if there is no source path.
     if (empty($source)) {
-      throw new \Exception("No scaffold file path given for $destination in package $package_name.");
+      throw new \Exception("No scaffold file path given for {$destination} in package {$package_name}.");
     }
-
     // Calculate the full path to the source scaffold file.
     $source_full_path = $package_path . '/' . $source;
-
     if (!file_exists($source_full_path)) {
-      throw new \Exception("Scaffold file $source not found in package $package_name.");
+      throw new \Exception("Scaffold file {$source} not found in package {$package_name}.");
     }
     if (is_dir($source_full_path)) {
-      throw new \Exception("Scaffold file $source in package $package_name is a directory; only files may be scaffolded.");
+      throw new \Exception("Scaffold file {$source} in package {$package_name} is a directory; only files may be scaffolded.");
     }
-
     return new self('src', $package_name, $source, $source_full_path);
   }
 
@@ -128,9 +122,8 @@ class ScaffoldFilePath {
    * @return self
    *   Object wrapping the relative and absolute path to the destination file.
    */
-  public static function destinationPath(string $package_name, string $destination, Interpolator $locationReplacements) : self {
+  public static function destinationPath($package_name, $destination, Interpolator $locationReplacements) {
     $dest_full_path = $locationReplacements->interpolate($destination);
-
     return new self('dest', $package_name, $destination, $dest_full_path);
   }
 
@@ -145,7 +138,7 @@ class ScaffoldFilePath {
    * @return self
    *   Object wrapping the relative and absolute path to the destination file.
    */
-  public static function autoloadPath(string $package_name, string $web_root) : self {
+  public static function autoloadPath($package_name, $web_root) {
     $rel_path = 'autoload.php';
     $dest_rel_path = '[web-root]/' . $rel_path;
     $dest_full_path = $web_root . '/' . $rel_path;
@@ -160,15 +153,11 @@ class ScaffoldFilePath {
    * @param string $namePrefix
    *   Prefix to add before -rel-path and -full-path item names. Defaults to path type.
    */
-  public function addInterpolationData(Interpolator $interpolator, string $namePrefix = '') {
+  public function addInterpolationData(Interpolator $interpolator, $namePrefix = '') {
     if (empty($namePrefix)) {
       $namePrefix = $this->type;
     }
-    $data = [
-      'package-name' => $this->packageName(),
-      "{$namePrefix}-rel-path" => $this->relativePath(),
-      "{$namePrefix}-full-path" => $this->fullPath(),
-    ];
+    $data = ['package-name' => $this->packageName(), "{$namePrefix}-rel-path" => $this->relativePath(), "{$namePrefix}-full-path" => $this->fullPath()];
     $interpolator->addData($data);
   }
 
@@ -181,7 +170,7 @@ class ScaffoldFilePath {
    * @return \Grasmash\ComposerScaffold\Interpolator
    *   An interpolator for making string replacements.
    */
-  public function getInterpolator($namePrefix = '') : Interpolator {
+  public function getInterpolator($namePrefix = '') {
     $interpolator = new Interpolator();
     $this->addInterpolationData($interpolator, $namePrefix);
     return $interpolator;

--- a/src/ScaffoldOptions.php
+++ b/src/ScaffoldOptions.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Grasmash\ComposerScaffold;
 
 use Composer\IO\IOInterface;
@@ -16,7 +14,6 @@ use Grasmash\ComposerScaffold\ScaffoldFilePath;
  * section of the project data.
  */
 class ScaffoldOptions {
-
   protected $options = [];
 
   /**
@@ -26,13 +23,7 @@ class ScaffoldOptions {
    *   The scaffold options taken from the 'composer-scaffold' section.
    */
   protected function __construct(array $options) {
-    $this->options = $options + [
-      "allowed-packages" => [],
-      "locations" => [],
-      "symlink" => FALSE,
-      "overwrite" => TRUE,
-      "file-mapping" => [],
-    ];
+    $this->options = $options + ["allowed-packages" => [], "locations" => [], "symlink" => FALSE, "overwrite" => TRUE, "file-mapping" => []];
   }
 
   /**
@@ -44,7 +35,7 @@ class ScaffoldOptions {
    * @return bool
    *   True if scaffold options have been declared
    */
-  public static function hasOptions(array $extras) : bool {
+  public static function hasOptions(array $extras) {
     return array_key_exists('composer-scaffold', $extras);
   }
 
@@ -57,7 +48,7 @@ class ScaffoldOptions {
    * @return self
    *   The scaffold options object representing the provided scaffold options
    */
-  public static function create(array $extras) : self {
+  public static function create(array $extras) {
     $options = static::hasOptions($extras) ? $extras['composer-scaffold'] : [];
     return new self($options);
   }
@@ -68,7 +59,7 @@ class ScaffoldOptions {
    * @return self
    *   A scaffold options object with default values
    */
-  public static function default() : self {
+  public static function default() {
     return new self([]);
   }
 
@@ -91,7 +82,7 @@ class ScaffoldOptions {
    * @return self
    *   The scaffold options object representing the provided scaffold options
    */
-  public function overrideSymlink(bool $symlink) {
+  public function overrideSymlink($symlink) {
     return $this->override(['symlink' => $symlink]);
   }
 
@@ -101,7 +92,7 @@ class ScaffoldOptions {
    * @return bool
    *   Whether there are allowed packages
    */
-  public function hasAllowedPackages() : bool {
+  public function hasAllowedPackages() {
     return !empty($this->allowedPackages());
   }
 
@@ -111,7 +102,7 @@ class ScaffoldOptions {
    * @return array
    *   The list of allowed packages
    */
-  public function allowedPackages() : array {
+  public function allowedPackages() {
     return $this->options['allowed-packages'];
   }
 
@@ -121,7 +112,7 @@ class ScaffoldOptions {
    * @return array
    *   A map of name : location values
    */
-  public function locations() : array {
+  public function locations() {
     return $this->options['locations'];
   }
 
@@ -131,7 +122,7 @@ class ScaffoldOptions {
    * @return bool
    *   True if the specified named location exist.
    */
-  public function hasLocation(string $name) : bool {
+  public function hasLocation($name) {
     return array_key_exists($name, $this->locations());
   }
 
@@ -146,7 +137,7 @@ class ScaffoldOptions {
    * @return string
    *   The value of the provided named location
    */
-  public function getLocation(string $name, string $default = '') : string {
+  public function getLocation($name, $default = '') {
     return $this->hasLocation($name) ? $this->locations()[$name] : $default;
   }
 
@@ -162,7 +153,7 @@ class ScaffoldOptions {
    * @return string
    *   The value of the provided named location
    */
-  public function requiredLocation(string $name, string $message) : string {
+  public function requiredLocation($name, $message) {
     if (!$this->hasLocation($name)) {
       throw new \Exception($message);
     }
@@ -175,7 +166,7 @@ class ScaffoldOptions {
    * @return bool
    *   Whether or not 'symlink' mode
    */
-  public function symlink() : bool {
+  public function symlink() {
     return $this->options['symlink'];
   }
 
@@ -185,7 +176,7 @@ class ScaffoldOptions {
    * @return bool
    *   Whether or not the scaffold options contain any file mappings
    */
-  public function hasFileMapping() : bool {
+  public function hasFileMapping() {
     return !empty($this->fileMapping());
   }
 
@@ -195,7 +186,7 @@ class ScaffoldOptions {
    * @return array
    *   File mappings for just this config type.
    */
-  public function fileMapping() : array {
+  public function fileMapping() {
     return $this->options['file-mapping'];
   }
 
@@ -205,7 +196,7 @@ class ScaffoldOptions {
    * @return bool
    *   The global the overwrite option
    */
-  public function overwrite() : bool {
+  public function overwrite() {
     return $this->options['overwrite'];
   }
 
@@ -215,7 +206,7 @@ class ScaffoldOptions {
    * @return bool
    *   Whether or not there is a 'gitignore' option setting
    */
-  public function hasGitIgnore() : bool {
+  public function hasGitIgnore() {
     return isset($this->options['gitignore']);
   }
 
@@ -225,7 +216,7 @@ class ScaffoldOptions {
    * @return bool
    *   The 'gitignore' option, or TRUE if undefined.
    */
-  public function gitIgnore() : bool {
+  public function gitIgnore() {
     return $this->hasGitIgnore() ? $this->options['gitignore'] : TRUE;
   }
 

--- a/src/ScaffoldOptions.php
+++ b/src/ScaffoldOptions.php
@@ -59,7 +59,7 @@ class ScaffoldOptions {
    * @return self
    *   A scaffold options object with default values
    */
-  public static function default() {
+  public static function defaultOptions() {
     return new self([]);
   }
 

--- a/tests/src/ExecTrait.php
+++ b/tests/src/ExecTrait.php
@@ -22,12 +22,12 @@ trait ExecTrait {
    * @return array
    *   Standard output and standard error from the command
    */
-  protected function mustExec(string $cmd, string $cwd, array $env = []) {
+  protected function mustExec($cmd, $cwd, array $env = []) {
     $process = new Process($cmd, $cwd, $env + ['PATH' => getenv('PATH'), 'HOME' => getenv('HOME')]);
     $process->setTimeout(300)->setIdleTimeout(300)->run();
     $exitCode = $process->getExitCode();
     if (0 != $exitCode) {
-      throw new \Exception("Exit code: $exitCode\n\n" . $process->getErrorOutput() . "\n\n" . $process->getOutput());
+      throw new \Exception("Exit code: {$exitCode}\n\n" . $process->getErrorOutput() . "\n\n" . $process->getOutput());
     }
     return [$process->getOutput(), $process->getErrorOutput()];
   }

--- a/tests/src/Fixtures.php
+++ b/tests/src/Fixtures.php
@@ -24,14 +24,12 @@ use Symfony\Component\Console\Output\BufferedOutput;
  * Convenience class for creating fixtures.
  */
 class Fixtures {
-
   /**
    * Directories to delete when we are done.
    *
    * @var string[]
    */
   protected $tmpDirs = [];
-
   protected $io;
   protected $composer;
 
@@ -41,7 +39,7 @@ class Fixtures {
    * @return \Composer\IO\IOInterface
    *   A Composer IOInterface to write to; output may be retrieved via Fixtures::getOutput()
    */
-  public function io() : IOInterface {
+  public function io() {
     if (!$this->io) {
       $this->io = new BufferIO();
     }
@@ -54,7 +52,7 @@ class Fixtures {
    * @return \Composer\Composer
    *   The main Composer object, needed by the scaffold Handler, etc.
    */
-  public function getComposer() : Composer {
+  public function getComposer() {
     if (!$this->composer) {
       $this->composer = Factory::create($this->io(), NULL, TRUE);
     }
@@ -99,11 +97,9 @@ class Fixtures {
    */
   public function projectFixtureDir($project_name) {
     $dir = $this->allFixturesDir() . '/' . $project_name;
-
     if (!is_dir($dir)) {
-      throw new \Exception("Requested fixture project $project_name that does not exist.");
+      throw new \Exception("Requested fixture project {$project_name} that does not exist.");
     }
-
     return $dir;
   }
 
@@ -115,11 +111,9 @@ class Fixtures {
    */
   public function binFixtureDir($bin_name) {
     $dir = $this->allFixturesDir() . '/scripts/' . $bin_name;
-
     if (!is_dir($dir)) {
-      throw new \Exception("Requested fixture bin dir $bin_name that does not exist.");
+      throw new \Exception("Requested fixture bin dir {$bin_name} that does not exist.");
     }
-
     return $dir;
   }
 
@@ -136,12 +130,11 @@ class Fixtures {
    * @return \Grasmash\ComposerScaffold\ScaffoldFilePath
    *   The full and relative path to the desired asset
    */
-  public function sourcePath(string $project_name, string $source, string $destination = 'unknown') : ScaffoldFilePath {
-    $package_name = "fixtures/$project_name";
-    $source_rel_path = "assets/$source";
+  public function sourcePath($project_name, $source, $destination = 'unknown') {
+    $package_name = "fixtures/{$project_name}";
+    $source_rel_path = "assets/{$source}";
     $package_path = $this->projectFixtureDir($project_name);
     $destination = 'unknown';
-
     return ScaffoldFilePath::sourcePath($package_name, $package_path, $destination, $source_rel_path);
   }
 
@@ -151,14 +144,10 @@ class Fixtures {
    * @return \Grasmash\ComposerScaffold\Interpolator
    *   An interpolator with location replacements, including 'web-root'.
    */
-  public function getLocationReplacements() : Interpolator {
+  public function getLocationReplacements() {
     $destinationTmpDir = $this->mkTmpDir();
     $interpolator = new Interpolator();
-    $interpolator->setData([
-      'web-root' => $destinationTmpDir,
-      'package-name' => 'fixtures/tmp-destination',
-    ]);
-
+    $interpolator->setData(['web-root' => $destinationTmpDir, 'package-name' => 'fixtures/tmp-destination']);
     return $interpolator;
   }
 
@@ -173,7 +162,7 @@ class Fixtures {
    * @return \Grasmash\ComposerScaffold\Operations\ReplaceOp
    *   A replace operation object.
    */
-  public function replaceOp(string $project_name, string $source) : ReplaceOp {
+  public function replaceOp($project_name, $source) {
     $source_path = $this->sourcePath($project_name, $source);
     return (new ReplaceOp())->setSource($source_path);
   }
@@ -189,7 +178,7 @@ class Fixtures {
    * @return \Grasmash\ComposerScaffold\Operations\AppendOp
    *   An append opperation object.
    */
-  public function appendOp(string $project_name, string $source) : AppendOp {
+  public function appendOp($project_name, $source) {
     $source_path = $this->sourcePath($project_name, $source);
     return (new AppendOp())->setAppendFile($source_path);
   }
@@ -211,10 +200,9 @@ class Fixtures {
    * @return \Grasmash\ComposerScaffold\ScaffoldFilePath
    *   A destination scaffold file backed by temporary storage.
    */
-  public function destinationPath(string $destination, Interpolator $interpolator = NULL, string $package_name = NULL) {
+  public function destinationPath($destination, Interpolator $interpolator = NULL, $package_name = NULL) {
     $interpolator = $interpolator ?: $this->getLocationReplacements();
     $package_name = $package_name ?: $interpolator->interpolate('[package-name]');
-
     return ScaffoldFilePath::destinationPath($package_name, $destination, $interpolator);
   }
 
@@ -230,7 +218,6 @@ class Fixtures {
   public function tmpDir($extraSalt = '') {
     $tmpDir = sys_get_temp_dir() . '/composer-scaffold-test-' . md5($extraSalt . microtime());
     $this->tmpDirs[] = $tmpDir;
-
     return $tmpDir;
   }
 
@@ -247,7 +234,6 @@ class Fixtures {
     $tmpDir = $this->tmpDir($extraSalt);
     $filesystem = new Filesystem();
     $filesystem->ensureDirectoryExists($tmpDir);
-
     return $tmpDir;
   }
 
@@ -280,16 +266,12 @@ class Fixtures {
    * @param array $replacements
    *   Key : value mappings for placeholders to replace in composer.json templates.
    */
-  public function cloneFixtureProjects(string $fixturesDir, array $replacements = []) {
+  public function cloneFixtureProjects($fixturesDir, array $replacements = []) {
     $filesystem = new Filesystem();
-    $replacements += [
-      'SYMLINK' => 'true',
-    ];
+    $replacements += ['SYMLINK' => 'true'];
     $interpolator = new Interpolator('__', '__', TRUE);
     $interpolator->setData($replacements);
-
     $filesystem->copy($this->allFixturesDir(), $fixturesDir);
-
     $composer_json_templates = glob($fixturesDir . "/*/composer.json.tmpl");
     foreach ($composer_json_templates as $composer_json_tmpl) {
       // Inject replacements into composer.json.
@@ -330,7 +312,7 @@ class Fixtures {
    * @return array
    *   Standard output and standard error from the command
    */
-  public function runComposer(string $cmd, string $cwd, int $expectedExitCode = 0) {
+  public function runComposer($cmd, $cwd, $expectedExitCode = 0) {
     chdir($cwd);
     $input = new StringInput($cmd);
     $output = new BufferedOutput();
@@ -343,7 +325,7 @@ class Fixtures {
       print "Exception: " . $e->getMessage() . "\n";
     }
     if ($exitCode != $expectedExitCode) {
-      print("Command '$cmd' - Expected exit code: $expectedExitCode, actual exit code: $exitCode\n");
+      print "Command '{$cmd}' - Expected exit code: {$expectedExitCode}, actual exit code: {$exitCode}\n";
     }
     $output = $output->fetch();
     return $output;

--- a/tests/src/Functional/ComposerHookTest.php
+++ b/tests/src/Functional/ComposerHookTest.php
@@ -24,10 +24,8 @@ use Symfony\Component\Process\Process;
  * information.
  */
 class ComposerHookTest extends TestCase {
-
   use ExecTrait;
   use AssertUtilsTrait;
-
   /**
    * The root of this project.
    *
@@ -37,14 +35,12 @@ class ComposerHookTest extends TestCase {
    * @var string
    */
   protected $projectRoot;
-
   /**
    * Directory to perform the tests in.
    *
    * @var string
    */
   protected $fixturesDir;
-
   /**
    * The Symfony FileSystem component.
    *
@@ -75,21 +71,14 @@ class ComposerHookTest extends TestCase {
   public function testComposerHooks() {
     $this->fixturesDir = $this->fixtures->tmpDir($this->getName());
     $is_link = FALSE;
-
-    $replacements = [
-      'SYMLINK' => $is_link ? 'true' : 'false',
-      'PROJECT_ROOT' => $this->projectRoot,
-    ];
+    $replacements = ['SYMLINK' => $is_link ? 'true' : 'false', 'PROJECT_ROOT' => $this->projectRoot];
     $this->fixtures->cloneFixtureProjects($this->fixturesDir, $replacements);
-
     $topLevelProjectDir = 'composer-hooks-fixture';
     $sut = $this->fixturesDir . '/' . $topLevelProjectDir;
-
     // First test: run composer install. This is the same as composer update
     // since there is no lock file. Ensure that scaffold operation ran.
     $this->execComposer("install --no-ansi", $sut);
     $this->assertScaffoldedFile($sut . '/sites/default/default.settings.php', $is_link, '#Test version of default.settings.php from drupal/core#');
-
     // Run composer required to add in the scaffold-override-fixture. This
     // project is "allowed" in our main fixture project, but not required.
     // We expect that requiring this library should re-scaffold, resulting
@@ -99,36 +88,30 @@ class ComposerHookTest extends TestCase {
     // Make sure that the appropriate notice informing us that scaffolding
     // is allowed was printed.
     $this->assertContains('Package fixtures/scaffold-override-fixture has scaffold operations, and is already allowed in the root-level composer.json file.', $stdout);
-
     // Delete one scaffold file, just for test purposes, then run
     // 'composer update' and see if the scaffold file is replaced.
     @unlink($sut . '/sites/default/default.settings.php');
     $this->execComposer("update --no-ansi", $sut);
     $this->assertScaffoldedFile($sut . '/sites/default/default.settings.php', $is_link, '#scaffolded from the scaffold-override-fixture#');
-
     // Delete the same test scaffold file again, then run
     // 'composer composer:scaffold' and see if the scaffold file is replaced.
     @unlink($sut . '/sites/default/default.settings.php');
     $this->execComposer("composer:scaffold --no-ansi", $sut);
     $this->assertScaffoldedFile($sut . '/sites/default/default.settings.php', $is_link, '#scaffolded from the scaffold-override-fixture#');
-
     // Run 'composer create-project' to create a new test project called
     // 'create-project-test', which is a copy of 'fixtures/drupal-drupal'.
     $packages = $this->fixturesDir . '/packages.json';
     $sut = $this->fixturesDir . '/create-project-test';
     $filesystem = new Filesystem();
     $filesystem->remove($sut);
-    list($stdout, $stderr) = $this->execComposer("create-project --repository=packages.json fixtures/drupal-drupal $sut", $this->fixturesDir, ['COMPOSER_MIRROR_PATH_REPOS' => 1]);
+    list($stdout, $stderr) = $this->execComposer("create-project --repository=packages.json fixtures/drupal-drupal {$sut}", $this->fixturesDir, ['COMPOSER_MIRROR_PATH_REPOS' => 1]);
     $this->assertDirectoryExists($sut);
     $this->assertContains('Scaffolding files for fixtures/drupal-drupal', $stdout);
     $this->assertScaffoldedFile($sut . '/index.php', FALSE, '#Test version of index.php from drupal/core#');
-
     $topLevelProjectDir = 'composer-hooks-nothing-allowed-fixture';
     $sut = $this->fixturesDir . '/' . $topLevelProjectDir;
-
     // Run composer install on an empty project.
     $this->execComposer("install --no-ansi", $sut);
-
     // Require a project that is not allowed to scaffold and confirm that we
     // get a warning, and it does not scaffold.
     list($stdout, $stderr) = $this->execComposer("require --no-ansi --no-interaction fixtures/scaffold-override-fixture:dev-master", $sut);
@@ -149,8 +132,8 @@ class ComposerHookTest extends TestCase {
    * @return array
    *   Standard output and standard error from the command
    */
-  protected function execComposer(string $cmd, string $cwd, array $env = []) {
-    return $this->mustExec("composer $cmd", $cwd, $env);
+  protected function execComposer($cmd, $cwd, array $env = []) {
+    return $this->mustExec("composer {$cmd}", $cwd, $env);
   }
 
 }

--- a/tests/src/Functional/ManageGitIgnoreTest.php
+++ b/tests/src/Functional/ManageGitIgnoreTest.php
@@ -19,10 +19,8 @@ use Symfony\Component\Process\Process;
  * repository's .gitignore file.
  */
 class ManageGitIgnoreTest extends TestCase {
-
   use ExecTrait;
   use AssertUtilsTrait;
-
   /**
    * The root of this project.
    *
@@ -32,14 +30,12 @@ class ManageGitIgnoreTest extends TestCase {
    * @var string
    */
   protected $projectRoot;
-
   /**
    * Directory to perform the tests in.
    *
    * @var string
    */
   protected $fixturesDir;
-
   /**
    * The Symfony FileSystem component.
    *
@@ -71,21 +67,14 @@ class ManageGitIgnoreTest extends TestCase {
     $is_link = FALSE;
     $this->fixturesDir = $this->fixtures->tmpDir($this->getName());
     $sut = $this->fixturesDir . '/' . $topLevelProjectDir;
-
-    $replacements = [
-      'SYMLINK' => $is_link ? 'true' : 'false',
-      'PROJECT_ROOT' => $this->projectRoot,
-    ];
+    $replacements = ['SYMLINK' => $is_link ? 'true' : 'false', 'PROJECT_ROOT' => $this->projectRoot];
     $this->fixtures->cloneFixtureProjects($this->fixturesDir, $replacements);
-
     // .gitignore files will not be managed unless there is a git repository.
     $this->mustExec('git init', $sut);
     $this->mustExec('git add .', $sut);
     $this->mustExec('git commit -m "Initial commit."', $sut);
-
     // Run composer install, but supress scaffolding.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $sut);
-
     return $sut;
   }
 
@@ -96,14 +85,11 @@ class ManageGitIgnoreTest extends TestCase {
     // Note that the drupal-composer-drupal-project fixture does not
     // have any configuration settings related to .gitignore management.
     $sut = $this->createSutWithGit('drupal-composer-drupal-project');
-
     $this->assertFileNotExists($sut . '/docroot/index.php');
     $this->assertFileNotExists($sut . '/docroot/sites/.gitignore');
-
     // Run the scaffold command.
     $this->fixtures->runScaffold($sut);
     $this->assertFileExists($sut . '/docroot/index.php');
-
     $expected = <<<EOT
 build
 .csslintrc
@@ -118,25 +104,21 @@ robots.txt
 update.php
 web.config
 EOT;
-
     // At this point we should have a .gitignore file, because although we
     // did not explicitly ask for .gitignore tracking, the vendor directory
     // is not tracked, so the default in that instance is to manage .gitignore files.
     $this->assertScaffoldedFile($sut . '/docroot/.gitignore', FALSE, '#' . $expected . '#msi');
     $this->assertScaffoldedFile($sut . '/docroot/sites/.gitignore', FALSE, '#example.settings.local.php#');
     $this->assertScaffoldedFile($sut . '/docroot/sites/default/.gitignore', FALSE, '#default.services.yml#');
-
     $expected = <<<EOT
 M docroot/.gitignore
 ?? docroot/sites/.gitignore
 ?? docroot/sites/default/.gitignore
 EOT;
-
     // Check to see whether there are any untracked files. We expect that
     // only the .gitignore files themselves should be untracked.
     list($stdout, $stderr) = $this->mustExec('git status --porcelain', $sut);
     $this->assertEquals(trim($expected), trim($stdout));
-
   }
 
   /**
@@ -147,7 +129,6 @@ EOT;
     // `"gitignore": false,` which disables .gitignore file handling.
     $sut = $this->createSutWithGit('drupal-drupal');
     $this->assertFileNotExists($sut . '/docroot/index.php');
-
     // Run the scaffold command.
     $this->fixtures->runScaffold($sut);
     $this->assertFileExists($sut . '/index.php');
@@ -165,25 +146,20 @@ EOT;
     // have any configuration settings related to .gitignore management.
     $sut = $this->createSutWithGit('drupal-composer-drupal-project');
     $this->assertFileNotExists($sut . '/docroot/sites/default/.gitignore');
-
     $this->assertFileNotExists($sut . '/docroot/index.php');
     $this->assertFileNotExists($sut . '/docroot/sites/.gitignore');
-
     // Confirm that 'git' is available (n.b. if it were not, createSutWithGit() would fail).
     exec('git --help', $output, $status);
     $this->assertEquals(0, $status);
-
     // Modify our $PATH so that it begins with a path that contains an executable
     // script named 'git' that always exits with 127, as if git were not found.
     // Note that we run our tests using process isolation, so we do not need to
     // restore the PATH when we are done.
     $unavailableGitPath = $this->fixtures->binFixtureDir('disable-git-bin');
     putenv('PATH=' . $unavailableGitPath . ':' . getenv('PATH'));
-
     // Confirm that 'git' is no longer available.
     exec('git --help', $output, $status);
     $this->assertEquals(127, $status);
-
     // Run the scaffold command.
     exec('composer composer:scaffold', $output, $status);
     $this->assertFileExists($sut . '/docroot/index.php');

--- a/tests/src/Functional/ScaffoldTest.php
+++ b/tests/src/Functional/ScaffoldTest.php
@@ -17,11 +17,8 @@ use Symfony\Component\Process\Process;
  * scaffold operations: copy, symlinks, skips and so on.
  */
 class ScaffoldTest extends TestCase {
-
   use AssertUtilsTrait;
-
   const FIXTURE_DIR = 'SCAFFOLD_FIXTURE_DIR';
-
   /**
    * The root of this project.
    *
@@ -31,21 +28,18 @@ class ScaffoldTest extends TestCase {
    * @var string
    */
   protected $projectRoot;
-
   /**
    * Directory to perform the tests in.
    *
    * @var string
    */
   protected $fixturesDir;
-
   /**
    * The file path to the system under test.
    *
    * @var string
    */
   protected $sut;
-
   /**
    * The Symfony FileSystem component.
    *
@@ -59,7 +53,6 @@ class ScaffoldTest extends TestCase {
   protected function setUp() {
     $this->fileSystem = new Filesystem();
     $this->fixtures = new Fixtures();
-
     $this->projectRoot = $this->fixtures->projectRoot();
     $this->fixturesDir = getenv(self::FIXTURE_DIR);
     if (!$this->fixturesDir) {
@@ -80,13 +73,10 @@ class ScaffoldTest extends TestCase {
    */
   protected function createSut($topLevelProjectDir, $replacements = []) {
     $this->sut = $this->fixturesDir . '/' . $topLevelProjectDir;
-
     // Erase just our sut, to ensure it is clean. Recopy all of the fixtures.
     $this->fileSystem->remove($this->sut);
-
     $replacements += ['PROJECT_ROOT' => $this->projectRoot];
     $this->fixtures->cloneFixtureProjects($this->fixturesDir, $replacements);
-
     return $this->sut;
   }
 
@@ -94,13 +84,7 @@ class ScaffoldTest extends TestCase {
    * Data provider for testComposerInstallScaffold and testScaffoldCommand.
    */
   public function scaffoldFixturesWithErrorConditionsTestValues() {
-    return [
-      [
-        'drupal-drupal-missing-scaffold-file',
-        'Scaffold file assets/missing-robots-default.txt not found in package fixtures/drupal-drupal-missing-scaffold-file.',
-        TRUE,
-      ],
-    ];
+    return [['drupal-drupal-missing-scaffold-file', 'Scaffold file assets/missing-robots-default.txt not found in package fixtures/drupal-drupal-missing-scaffold-file.', TRUE]];
   }
 
   /**
@@ -109,13 +93,9 @@ class ScaffoldTest extends TestCase {
    * @dataProvider scaffoldFixturesWithErrorConditionsTestValues
    */
   public function testScaffoldFixturesWithErrorConditions($topLevelProjectDir, $expectedExceptionMessage, $is_link) {
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => $is_link ? 'true' : 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => $is_link ? 'true' : 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test scaffold. Expect an error.
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage($expectedExceptionMessage);
@@ -126,33 +106,7 @@ class ScaffoldTest extends TestCase {
    * Data provider for testComposerInstallScaffold and testScaffoldCommand.
    */
   public function scaffoldTestValues() {
-    return [
-      [
-        'drupal-composer-drupal-project',
-        'assertDrupalProjectSutWasScaffolded',
-        TRUE,
-      ],
-      [
-        'drupal-drupal',
-        'assertDrupalDrupalSutWasScaffolded',
-        FALSE,
-      ],
-      [
-        'drupal-drupal-test-overwrite',
-        'assertDrupalDrupalFileWasReplaced',
-        FALSE,
-      ],
-      [
-        'drupal-drupal-test-append',
-        'assertDrupalDrupalFileWasAppended',
-        FALSE,
-      ],
-      [
-        'drupal-drupal-test-append',
-        'assertDrupalDrupalFileWasAppended',
-        TRUE,
-      ],
-    ];
+    return [['drupal-composer-drupal-project', 'assertDrupalProjectSutWasScaffolded', TRUE], ['drupal-drupal', 'assertDrupalDrupalSutWasScaffolded', FALSE], ['drupal-drupal-test-overwrite', 'assertDrupalDrupalFileWasReplaced', FALSE], ['drupal-drupal-test-append', 'assertDrupalDrupalFileWasAppended', FALSE], ['drupal-drupal-test-append', 'assertDrupalDrupalFileWasAppended', TRUE]];
   }
 
   /**
@@ -161,13 +115,9 @@ class ScaffoldTest extends TestCase {
    * @dataProvider scaffoldTestValues
    */
   public function testScaffold($topLevelProjectDir, $scaffoldAssertions, $is_link) {
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => $is_link ? 'true' : 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => $is_link ? 'true' : 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test composer:scaffold.
     $scaffoldOutput = $this->fixtures->runScaffold($sut);
     // @todo We could assert that $scaffoldOutput must contain some expected text
@@ -179,13 +129,9 @@ class ScaffoldTest extends TestCase {
    */
   public function testEmptyProject() {
     $topLevelProjectDir = 'empty-fixture';
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test composer:scaffold.
     $scaffoldOutput = $this->fixtures->runScaffold($sut);
     $this->assertEquals('', $scaffoldOutput);
@@ -196,17 +142,12 @@ class ScaffoldTest extends TestCase {
    */
   public function testProjectThatScaffoldsEmptyProject() {
     $topLevelProjectDir = 'project-allowing-empty-fixture';
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test composer:scaffold.
     $scaffoldOutput = $this->fixtures->runScaffold($sut);
     $this->assertContains('The allowed package fixtures/empty-fixture does not provide a file mapping for Composer Scaffold', $scaffoldOutput);
-
     $docroot = $sut;
     $this->assertCommonDrupalAssetsWereScaffolded($docroot, FALSE, $topLevelProjectDir);
   }
@@ -216,13 +157,9 @@ class ScaffoldTest extends TestCase {
    */
   public function testProjectWithEmptyScaffoldPath() {
     $topLevelProjectDir = 'project-with-empty-scaffold-path';
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test composer:scaffold.
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('No scaffold file path given for [web-root]/my-error in package fixtures/project-with-empty-scaffold-path');
@@ -234,13 +171,9 @@ class ScaffoldTest extends TestCase {
    */
   public function testProjectWithIllegalDirScaffold() {
     $topLevelProjectDir = 'project-with-illegal-dir-scaffold';
-    $sut = $this->createSut($topLevelProjectDir, [
-      'SYMLINK' => 'false',
-    ]);
-
+    $sut = $this->createSut($topLevelProjectDir, ['SYMLINK' => 'false']);
     // Run composer install to get the dependencies we need to test.
     $this->fixtures->runComposer("install --no-ansi --no-scripts", $this->sut);
-
     // Test composer:scaffold.
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Scaffold file assets in package fixtures/project-with-illegal-dir-scaffold is a directory; only files may be scaffolded');
@@ -252,7 +185,6 @@ class ScaffoldTest extends TestCase {
    */
   protected function assertDrupalProjectSutWasScaffolded($sut, $is_link, $project_name) {
     $docroot = $sut . '/docroot';
-
     $this->assertCommonDrupalAssetsWereScaffolded($docroot, $is_link, $project_name);
     $this->assertDefaultSettingsFromScaffoldOverride($docroot, $is_link);
     $this->assertHtaccessExcluded($docroot);
@@ -263,7 +195,6 @@ class ScaffoldTest extends TestCase {
    */
   protected function assertDrupalDrupalSutWasScaffolded($sut, $is_link, $project_name) {
     $docroot = $sut;
-
     $this->assertCommonDrupalAssetsWereScaffolded($docroot, $is_link, $project_name);
     $this->assertDefaultSettingsFromScaffoldOverride($docroot, $is_link);
     $this->assertHtaccessExcluded($docroot);
@@ -294,13 +225,11 @@ class ScaffoldTest extends TestCase {
    */
   protected function assertDrupalDrupalFileWasReplaced($sut, $is_link, $project_name) {
     $docroot = $sut;
-
     $this->assertScaffoldedFile($docroot . '/replace-me.txt', $is_link, '#from assets that replaces file#');
     $this->assertScaffoldedFile($docroot . '/keep-me.txt', $is_link, '#File in drupal-drupal-test-overwrite that is not replaced#');
     $this->assertScaffoldedFile($docroot . '/make-me.txt', $is_link, '#from assets that replaces file#');
-
     $this->assertCommonDrupalAssetsWereScaffolded($docroot, $is_link, $project_name);
-    $this->assertScaffoldedFile($docroot . '/robots.txt', $is_link, "#$project_name#");
+    $this->assertScaffoldedFile($docroot . '/robots.txt', $is_link, "#{$project_name}#");
   }
 
   /**
@@ -308,9 +237,7 @@ class ScaffoldTest extends TestCase {
    */
   protected function assertDrupalDrupalFileWasAppended($sut, $is_link, $project_name) {
     $docroot = $sut;
-
     $this->assertScaffoldedFile($docroot . '/robots.txt', FALSE, '#in drupal-drupal-test-append composer.json fixture.*This content is prepended to the top of the existing robots.txt fixture.*Test version of robots.txt from drupal/core.*This content is appended to the bottom of the existing robots.txt fixture.*in drupal-drupal-test-append composer.json fixture#ms');
-
     $this->assertCommonDrupalAssetsWereScaffolded($docroot, $is_link, $project_name);
   }
 
@@ -322,12 +249,10 @@ class ScaffoldTest extends TestCase {
    * in different ways in different tests.
    */
   protected function assertCommonDrupalAssetsWereScaffolded($docroot, $is_link, $project_name) {
-    $from_project = "#scaffolded from \"file-mappings\" in $project_name composer.json fixture#";
+    $from_project = "#scaffolded from \"file-mappings\" in {$project_name} composer.json fixture#";
     $from_core = '#from drupal/core#';
-
     // Ensure that the autoload.php file was written.
     $this->assertFileExists($docroot . '/autoload.php');
-
     // Assert other scaffold files are written in the correct locations.
     $this->assertScaffoldedFile($docroot . '/.csslintrc', $is_link, $from_core);
     $this->assertScaffoldedFile($docroot . '/.editorconfig', $is_link, $from_core);

--- a/tests/src/Integration/AppendOpTest.php
+++ b/tests/src/Integration/AppendOpTest.php
@@ -22,36 +22,26 @@ class AppendOpTest extends TestCase {
    */
   public function testProcess() {
     $fixtures = new Fixtures();
-
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-
     $options = ScaffoldOptions::default();
-
     $originalOp = new ReplaceOp();
     $originalOp->setSource($source);
     $originalOp->setOverwrite(TRUE);
-
     $prepend = $fixtures->sourcePath('drupal-drupal-test-append', 'prepend-to-robots.txt');
     $append = $fixtures->sourcePath('drupal-drupal-test-append', 'append-to-robots.txt');
-
     $sut = new AppendOp();
     $sut->setOriginalOp($originalOp);
     $sut->setPrependFile($prepend);
     $sut->setAppendFile($append);
-
     // Assert that there is no target file before we run our test.
     $this->assertFileNotExists($destination->fullPath());
-
     // Test the system under test.
     $sut->process($destination, $fixtures->io(), $options);
-
     // Assert that the target file was created.
     $this->assertFileExists($destination->fullPath());
-
     // Assert the target contained the contents from the correct scaffold files.
     $contents = trim(file_get_contents($destination->fullPath()));
-
     $expected = <<<EOT
 # robots.txt fixture scaffolded from "file-mappings" in drupal-drupal-test-append composer.json fixture.
 # This content is prepended to the top of the existing robots.txt fixture.
@@ -63,9 +53,7 @@ class AppendOpTest extends TestCase {
 # This content is appended to the bottom of the existing robots.txt fixture.
 # robots.txt fixture scaffolded from "file-mappings" in drupal-drupal-test-append composer.json fixture.
 EOT;
-
     $this->assertEquals(trim($expected), $contents);
-
     // Confirm that expected output was written to our io fixture.
     $output = $fixtures->getOutput();
     $this->assertContains('Copy [web-root]/robots.txt from assets/robots.txt', $output);

--- a/tests/src/Integration/AppendOpTest.php
+++ b/tests/src/Integration/AppendOpTest.php
@@ -24,7 +24,7 @@ class AppendOpTest extends TestCase {
     $fixtures = new Fixtures();
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-    $options = ScaffoldOptions::default();
+    $options = ScaffoldOptions::defaultOptions();
     $originalOp = new ReplaceOp();
     $originalOp->setSource($source);
     $originalOp->setOverwrite(TRUE);

--- a/tests/src/Integration/OperationCollectionTest.php
+++ b/tests/src/Integration/OperationCollectionTest.php
@@ -22,40 +22,19 @@ class OperationCollectionTest extends TestCase {
    */
   public function testCoalateScaffoldFiles() {
     $fixtures = new Fixtures();
-
     $locationReplacements = $fixtures->getLocationReplacements();
-
-    $file_mappings = [
-      'fixtures/drupal-assets-fixture' => [
-        '[web-root]/index.php' => $fixtures->replaceOp('drupal-assets-fixture', 'index.php'),
-        '[web-root]/.htaccess' => $fixtures->replaceOp('drupal-assets-fixture', '.htaccess'),
-        '[web-root]/robots.txt' => $fixtures->replaceOp('drupal-assets-fixture', 'robots.txt'),
-        '[web-root]/sites/default/default.services.yml' => $fixtures->replaceOp('drupal-assets-fixture', 'default.services.yml'),
-      ],
-      'fixtures/drupal-profile' => [
-        '[web-root]/sites/default/default.services.yml' => $fixtures->replaceOp('drupal-profile', 'profile.default.services.yml'),
-      ],
-      'fixtures/drupal-drupal' => [
-        '[web-root]/.htaccess' => new SkipOp(),
-        '[web-root]/robots.txt' => $fixtures->appendOp('drupal-drupal-test-append', 'append-to-robots.txt'),
-      ],
-    ];
-
+    $file_mappings = ['fixtures/drupal-assets-fixture' => ['[web-root]/index.php' => $fixtures->replaceOp('drupal-assets-fixture', 'index.php'), '[web-root]/.htaccess' => $fixtures->replaceOp('drupal-assets-fixture', '.htaccess'), '[web-root]/robots.txt' => $fixtures->replaceOp('drupal-assets-fixture', 'robots.txt'), '[web-root]/sites/default/default.services.yml' => $fixtures->replaceOp('drupal-assets-fixture', 'default.services.yml')], 'fixtures/drupal-profile' => ['[web-root]/sites/default/default.services.yml' => $fixtures->replaceOp('drupal-profile', 'profile.default.services.yml')], 'fixtures/drupal-drupal' => ['[web-root]/.htaccess' => new SkipOp(), '[web-root]/robots.txt' => $fixtures->appendOp('drupal-drupal-test-append', 'append-to-robots.txt')]];
     $sut = new OperationCollection($fixtures->io());
-
     // Test the system under test.
     $sut->coalateScaffoldFiles($file_mappings, $locationReplacements);
     $resolved_file_mappings = $sut->fileMappings();
     $scaffold_list = $sut->scaffoldList();
-
     // Confirm that the keys of the output are the same as the keys of the input.
     $this->assertEquals(array_keys($file_mappings), array_keys($resolved_file_mappings));
-
     // Also assert that we have the right ScaffoldFileInfo objects in the destination.
     $this->assertResolvedToSameOp('fixtures/drupal-assets-fixture', '[web-root]/index.php', $file_mappings, $scaffold_list, $resolved_file_mappings);
     $this->assertResolvedToSameOp('fixtures/drupal-profile', '[web-root]/sites/default/default.services.yml', $file_mappings, $scaffold_list, $resolved_file_mappings);
     $this->assertResolvedToSameOp('fixtures/drupal-drupal', '[web-root]/robots.txt', $file_mappings, $scaffold_list, $resolved_file_mappings);
-
     // Assert that the files below have been overridden.
     $this->assertOverridden('fixtures/drupal-assets-fixture', '[web-root]/.htaccess', $scaffold_list, $resolved_file_mappings);
     $this->assertOverridden('fixtures/drupal-assets-fixture', '[web-root]/robots.txt', $scaffold_list, $resolved_file_mappings);
@@ -73,7 +52,6 @@ class OperationCollectionTest extends TestCase {
     $resolved_scaffold_op = $resolved_file_info->op();
     $this->assertEquals(get_class($file_mappings[$project][$dest]), get_class($resolved_scaffold_op));
     $this->assertEquals($file_mappings[$project][$dest], $resolved_scaffold_op);
-
     $this->assertEquals($project, $scaffold_list[$dest]->packageName());
   }
 

--- a/tests/src/Integration/ReplaceOpTest.php
+++ b/tests/src/Integration/ReplaceOpTest.php
@@ -21,29 +21,21 @@ class ReplaceOpTest extends TestCase {
    */
   public function testProcess() {
     $fixtures = new Fixtures();
-
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-
     $options = ScaffoldOptions::default();
-
     $sut = new ReplaceOp();
     $sut->setSource($source);
     $sut->setOverwrite(TRUE);
-
     // Assert that there is no target file before we run our test.
     $this->assertFileNotExists($destination->fullPath());
-
     // Test the system under test.
     $sut->process($destination, $fixtures->io(), $options);
-
     // Assert that the target file was created.
     $this->assertFileExists($destination->fullPath());
-
     // Assert the target contained the contents from the correct scaffold file.
     $contents = trim(file_get_contents($destination->fullPath()));
     $this->assertEquals('# Test version of robots.txt from drupal/core.', $contents);
-
     // Confirm that expected output was written to our io fixture.
     $output = $fixtures->getOutput();
     $this->assertContains('Copy [web-root]/robots.txt from assets/robots.txt', $output);

--- a/tests/src/Integration/ReplaceOpTest.php
+++ b/tests/src/Integration/ReplaceOpTest.php
@@ -23,7 +23,7 @@ class ReplaceOpTest extends TestCase {
     $fixtures = new Fixtures();
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-    $options = ScaffoldOptions::default();
+    $options = ScaffoldOptions::defaultOptions();
     $sut = new ReplaceOp();
     $sut->setSource($source);
     $sut->setOverwrite(TRUE);

--- a/tests/src/Integration/SkipOpTest.php
+++ b/tests/src/Integration/SkipOpTest.php
@@ -23,7 +23,7 @@ class SkipOpTest extends TestCase {
     $fixtures = new Fixtures();
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-    $options = ScaffoldOptions::default();
+    $options = ScaffoldOptions::defaultOptions();
     $sut = new SkipOp();
     // Assert that there is no target file before we run our test.
     $this->assertFileNotExists($destination->fullPath());

--- a/tests/src/Integration/SkipOpTest.php
+++ b/tests/src/Integration/SkipOpTest.php
@@ -21,23 +21,16 @@ class SkipOpTest extends TestCase {
    */
   public function testProcess() {
     $fixtures = new Fixtures();
-
     $destination = $fixtures->destinationPath('[web-root]/robots.txt');
     $source = $fixtures->sourcePath('drupal-assets-fixture', 'robots.txt');
-
     $options = ScaffoldOptions::default();
-
     $sut = new SkipOp();
-
     // Assert that there is no target file before we run our test.
     $this->assertFileNotExists($destination->fullPath());
-
     // Test the system under test.
     $sut->process($destination, $fixtures->io(), $options);
-
     // Assert that the target file was not created.
     $this->assertFileNotExists($destination->fullPath());
-
     // Confirm that expected output was written to our io fixture.
     $output = $fixtures->getOutput();
     $this->assertContains('Skip [web-root]/robots.txt: disabled', $output);

--- a/tests/src/Unit/HandlerTest.php
+++ b/tests/src/Unit/HandlerTest.php
@@ -12,14 +12,12 @@ use PHPUnit\Framework\TestCase;
  * @coversDefaultClass \Grasmash\ComposerScaffold\Handler
  */
 class HandlerTest extends TestCase {
-
   /**
    * The Composer service.
    *
    * @var \Composer\IO\IOInterface
    */
   protected $composer;
-
   /**
    * The Composer IO service.
    *
@@ -32,7 +30,6 @@ class HandlerTest extends TestCase {
    */
   protected function setUp() {
     parent::setUp();
-
     $this->composer = $this->prophesize(Composer::class);
     $this->io = $this->prophesize(IOInterface::class);
   }
@@ -42,30 +39,16 @@ class HandlerTest extends TestCase {
    */
   public function testGetWebRoot() {
     $expected = './build/docroot';
-    $extra = [
-      'composer-scaffold' => [
-        'locations' => [
-          'web-root' => $expected,
-        ],
-      ],
-    ];
-
+    $extra = ['composer-scaffold' => ['locations' => ['web-root' => $expected]]];
     $package = $this->prophesize(PackageInterface::class);
     $package->getExtra()->willReturn($extra);
-
     $this->composer->getPackage()->willReturn($package->reveal());
-
     $fixture = new Handler($this->composer->reveal(), $this->io->reveal());
     $this->assertSame($expected, $fixture->getWebRoot());
-
     // Verify correct errors.
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('The extra.composer-scaffold.location.web-root is not set in composer.json.');
-    $extra = [
-      'allowed-packages' => [
-        'foo/bar',
-      ],
-    ];
+    $extra = ['allowed-packages' => ['foo/bar']];
     $package->getExtra()->willReturn($extra);
     $this->composer->getPackage()->willReturn($package->reveal());
     $fixture = new Handler($this->composer->reveal(), $this->io->reveal());


### PR DESCRIPTION
**WIP, DO NOT COMMIT**

This branch was created as follows:
```
rm -rf vendor
php7to5 convert $(pwd) ../composer-scaffold-5
composer install
rsync -azvr ../composer-scaffold-5/ .
composer cbf
```

Note that `php7to5` reformats the output; `cbf` fixes most of the style changes that are introduced, but some lines are re-flowed and end up being too long. These will probably have to be corrected by hand.

This is just a POC; we should re-run this script after #37 is merged.